### PR TITLE
Flags

### DIFF
--- a/src/PuppeteerSharp.Contrib.Extensions.Unsafe/ElementHandleExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions.Unsafe/ElementHandleExtensions.cs
@@ -121,24 +121,26 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// Indicates whether the element has the specified content or not.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns><c>true</c> if the element has the specified content</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static bool HasContent(this ElementHandle elementHandle, string content)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static bool HasContent(this ElementHandle elementHandle, string regex, string flags = "")
         {
-            return elementHandle.HasContentAsync(content).Result();
+            return elementHandle.HasContentAsync(regex, flags).Result();
         }
 
         /// <summary>
         /// Indicates whether the element has the specified content or not.
         /// </summary>
         /// <param name="elementHandleTask">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns><c>true</c> if the element has the specified content</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static bool HasContent(this Task<ElementHandle> elementHandleTask, string content)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static bool HasContent(this Task<ElementHandle> elementHandleTask, string regex, string flags = "")
         {
-            return elementHandleTask.GuardFromNull().Result().HasContent(content);
+            return elementHandleTask.GuardFromNull().Result().HasContent(regex, flags);
         }
 
         // ClassName

--- a/src/PuppeteerSharp.Contrib.Extensions/ElementHandleExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/ElementHandleExtensions.cs
@@ -17,16 +17,18 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <param name="elementHandle">An <see cref="ElementHandle"/> to query</param>
         /// <param name="selector">A selector to query element for</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns>Task which resolves to <see cref="ElementHandle"/> pointing to the element</returns>
-        public static async Task<ElementHandle> QuerySelectorWithContentAsync(this ElementHandle elementHandle, string selector, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<ElementHandle> QuerySelectorWithContentAsync(this ElementHandle elementHandle, string selector, string regex, string flags = "")
         {
             return await elementHandle.GuardFromNull().EvaluateFunctionHandleAsync(
-                @"(element, selector, regex) => {
+                @"(element, selector, regex, flags) => {
                     var elements = element.querySelectorAll(selector);
                     return Array.prototype.find.call(elements, function(element) {
-                        return RegExp(regex).test(element.textContent);
+                        return RegExp(regex, flags).test(element.textContent);
                     });
-                }", selector, regex).ConfigureAwait(false) as ElementHandle;
+                }", selector, regex, flags).ConfigureAwait(false) as ElementHandle;
         }
 
         /// <summary>
@@ -35,16 +37,18 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <param name="elementHandle">An <see cref="ElementHandle"/> to query</param>
         /// <param name="selector">A selector to query element for</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns>Task which resolves to ElementHandles pointing to the elements</returns>
-        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this ElementHandle elementHandle, string selector, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this ElementHandle elementHandle, string selector, string regex, string flags = "")
         {
             var arrayHandle = await elementHandle.GuardFromNull().EvaluateFunctionHandleAsync(
-                @"(element, selector, regex) => {
+                @"(element, selector, regex, flags) => {
                     var elements = element.querySelectorAll(selector);
                     return Array.prototype.filter.call(elements, function(element) {
-                        return RegExp(regex).test(element.textContent);
+                        return RegExp(regex, flags).test(element.textContent);
                     });
-                }", selector, regex).ConfigureAwait(false);
+                }", selector, regex, flags).ConfigureAwait(false);
 
             if (arrayHandle == null) throw new InvalidOperationException("EvaluateFunctionHandleAsync returned null.");
 
@@ -112,12 +116,13 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// Indicates whether the element has the specified content or not.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns><c>true</c> if the element has the specified content</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static async Task<bool> HasContentAsync(this ElementHandle elementHandle, string content)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<bool> HasContentAsync(this ElementHandle elementHandle, string regex, string flags = "")
         {
-            return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("(node, content) => node.textContent.includes(content)", content).ConfigureAwait(false);
+            return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("(element, regex, flags) => RegExp(regex, flags).test(element.textContent)", regex, flags).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/PuppeteerSharp.Contrib.Extensions/PageExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/PageExtensions.cs
@@ -14,18 +14,18 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <param name="page">A <see cref="Page"/> to query</param>
         /// <param name="selector">A selector to query page for</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns>Task which resolves to <see cref="ElementHandle"/> pointing to the frame element</returns>
-        public static async Task<ElementHandle> QuerySelectorWithContentAsync(this Page page, string selector, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<ElementHandle> QuerySelectorWithContentAsync(this Page page, string selector, string regex, string flags = "")
         {
-            var handle = await page.GuardFromNull().EvaluateFunctionHandleAsync(
-                @"(selector, regex) => {
+            return await page.GuardFromNull().EvaluateFunctionHandleAsync(
+                @"(selector, regex, flags) => {
                     var elements = document.querySelectorAll(selector);
                     return Array.prototype.find.call(elements, function(element) {
-                        return RegExp(regex).test(element.textContent);
+                        return RegExp(regex, flags).test(element.textContent);
                     });
-                }", selector, regex).ConfigureAwait(false) as ElementHandle;
-
-            return handle;
+                }", selector, regex, flags).ConfigureAwait(false) as ElementHandle;
         }
 
         /// <summary>
@@ -34,16 +34,18 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <param name="page">A <see cref="Page"/> to query</param>
         /// <param name="selector">A selector to query page for</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns>Task which resolves to ElementHandles pointing to the frame elements</returns>
-        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this Page page, string selector, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this Page page, string selector, string regex, string flags = "")
         {
             var arrayHandle = await page.GuardFromNull().EvaluateFunctionHandleAsync(
-                @"(selector, regex) => {
+                @"(selector, regex, flags) => {
                     var elements = document.querySelectorAll(selector);
                     return Array.prototype.filter.call(elements, function(element) {
-                        return RegExp(regex).test(element.textContent);
+                        return RegExp(regex, flags).test(element.textContent);
                     });
-                }", selector, regex).ConfigureAwait(false);
+                }", selector, regex, flags).ConfigureAwait(false);
 
             var properties = await arrayHandle.GetPropertiesAsync().ConfigureAwait(false);
             await arrayHandle.DisposeAsync().ConfigureAwait(false);
@@ -56,10 +58,12 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns><c>true</c> if the page has the specified content</returns>
-        public static async Task<bool> HasContentAsync(this Page page, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<bool> HasContentAsync(this Page page, string regex, string flags = "")
         {
-            return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex) => RegExp(regex).test(document.documentElement.textContent)", regex).ConfigureAwait(false);
+            return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex, flags) => RegExp(regex, flags).test(document.documentElement.textContent)", regex, flags).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -67,10 +71,12 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.title</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <returns><c>true</c> if the page has the specified title</returns>
-        public static async Task<bool> HasTitleAsync(this Page page, string regex)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task<bool> HasTitleAsync(this Page page, string regex, string flags = "")
         {
-            return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex) => RegExp(regex).test(document.title)", regex).ConfigureAwait(false);
+            return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex, flags) => RegExp(regex, flags).test(document.title)", regex, flags).ConfigureAwait(false);
         }
     }
 }

--- a/src/PuppeteerSharp.Contrib.Should.Unsafe/ElementHandleShouldExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should.Unsafe/ElementHandleShouldExtensions.cs
@@ -143,13 +143,14 @@ namespace PuppeteerSharp.Contrib.Should
         /// Asserts that the element has the specified content.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>The <see cref="ElementHandle"/> for method chaining</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static ElementHandle ShouldHaveContent(this ElementHandle elementHandle, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static ElementHandle ShouldHaveContent(this ElementHandle elementHandle, string regex, string flags = "", string because = null)
         {
-            elementHandle.ShouldHaveContentAsync(content, because).Result();
+            elementHandle.ShouldHaveContentAsync(regex, flags, because).Result();
 
             return elementHandle;
         }
@@ -158,25 +159,27 @@ namespace PuppeteerSharp.Contrib.Should
         /// Asserts that the element has the specified content.
         /// </summary>
         /// <param name="elementHandleTask">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static void ShouldHaveContent(this Task<ElementHandle> elementHandleTask, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static void ShouldHaveContent(this Task<ElementHandle> elementHandleTask, string regex, string flags = "", string because = null)
         {
-            elementHandleTask.Result().ShouldHaveContentAsync(content, because).Result();
+            elementHandleTask.Result().ShouldHaveContentAsync(regex, flags, because).Result();
         }
 
         /// <summary>
         /// Asserts that the element does not have the specified content.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>The <see cref="ElementHandle"/> for method chaining</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static ElementHandle ShouldNotHaveContent(this ElementHandle elementHandle, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static ElementHandle ShouldNotHaveContent(this ElementHandle elementHandle, string regex, string flags = "", string because = null)
         {
-            elementHandle.ShouldNotHaveContentAsync(content, because).Result();
+            elementHandle.ShouldNotHaveContentAsync(regex, flags, because).Result();
 
             return elementHandle;
         }
@@ -185,12 +188,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// Asserts that the element does not have the specified content.
         /// </summary>
         /// <param name="elementHandleTask">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static void ShouldNotHaveContent(this Task<ElementHandle> elementHandleTask, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static void ShouldNotHaveContent(this Task<ElementHandle> elementHandleTask, string regex, string flags = "", string because = null)
         {
-            elementHandleTask.Result().ShouldNotHaveContentAsync(content, because).Result();
+            elementHandleTask.Result().ShouldNotHaveContentAsync(regex, flags, because).Result();
         }
 
         // Class

--- a/src/PuppeteerSharp.Contrib.Should/ElementHandleShouldExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should/ElementHandleShouldExtensions.cs
@@ -98,26 +98,28 @@ namespace PuppeteerSharp.Contrib.Should
         /// Asserts that the element has the specified content.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static async Task ShouldHaveContentAsync(this ElementHandle elementHandle, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldHaveContentAsync(this ElementHandle elementHandle, string regex, string flags = "", string because = null)
         {
-            if (!await elementHandle.HasContentAsync(content).ConfigureAwait(false)) Throw.ShouldHaveContent(elementHandle, content, because);
+            if (!await elementHandle.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldHaveContent(elementHandle, regex, flags, because);
         }
 
         /// <summary>
         /// Asserts that the element does not have the specified content.
         /// </summary>
         /// <param name="elementHandle">An <see cref="ElementHandle"/></param>
-        /// <param name="content">The content</param>
+        /// <param name="regex">A regular expression to test against <c>element.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        /// <remarks>Evaluates <c>node.textContent</c></remarks>
-        public static async Task ShouldNotHaveContentAsync(this ElementHandle elementHandle, string content, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldNotHaveContentAsync(this ElementHandle elementHandle, string regex, string flags = "", string because = null)
         {
-            if (await elementHandle.HasContentAsync(content).ConfigureAwait(false)) Throw.ShouldNotHaveContent(elementHandle, content, because);
+            if (await elementHandle.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldNotHaveContent(elementHandle, regex, flags, because);
         }
 
         // Class

--- a/src/PuppeteerSharp.Contrib.Should/PageShouldExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should/PageShouldExtensions.cs
@@ -13,11 +13,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldHaveContentAsync(this Page page, string regex, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldHaveContentAsync(this Page page, string regex, string flags = "", string because = null)
         {
-            if (!await page.HasContentAsync(regex).ConfigureAwait(false)) Throw.ShouldHaveContent(page, regex, because);
+            if (!await page.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldHaveContent(page, regex, flags, because);
         }
 
         /// <summary>
@@ -25,11 +27,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldNotHaveContentAsync(this Page page, string regex, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldNotHaveContentAsync(this Page page, string regex, string flags = "", string because = null)
         {
-            if (await page.HasContentAsync(regex).ConfigureAwait(false)) Throw.ShouldNotHaveContent(page, regex, because);
+            if (await page.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldNotHaveContent(page, regex, flags, because);
         }
 
         /// <summary>
@@ -37,11 +41,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.title</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldHaveTitleAsync(this Page page, string regex, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldHaveTitleAsync(this Page page, string regex, string flags = "", string because = null)
         {
-            if (!await page.HasTitleAsync(regex).ConfigureAwait(false)) Throw.ShouldHaveTitle(page, regex, await page.GuardFromNull().GetTitleAsync().ConfigureAwait(false), because);
+            if (!await page.HasTitleAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldHaveTitle(page, regex, flags, await page.GuardFromNull().GetTitleAsync().ConfigureAwait(false), because);
         }
 
         /// <summary>
@@ -49,11 +55,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// </summary>
         /// <param name="page">A <see cref="Page"/></param>
         /// <param name="regex">A regular expression to test against <c>document.title</c></param>
+        /// <param name="flags">A set of flags for the regular expression</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldNotHaveTitleAsync(this Page page, string regex, string because = null)
+        /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
+        public static async Task ShouldNotHaveTitleAsync(this Page page, string regex, string flags = "", string because = null)
         {
-            if (await page.HasTitleAsync(regex).ConfigureAwait(false)) Throw.ShouldNotHaveTitle(page, regex, because);
+            if (await page.HasTitleAsync(regex, flags).ConfigureAwait(false)) Throw.ShouldNotHaveTitle(page, regex, flags, because);
         }
     }
 }

--- a/src/PuppeteerSharp.Contrib.Should/Throw.cs
+++ b/src/PuppeteerSharp.Contrib.Should/Throw.cs
@@ -4,24 +4,24 @@ namespace PuppeteerSharp.Contrib.Should
     {
         /* Page */
 
-        public static void ShouldHaveContent(Page page, string regex, string because)
+        public static void ShouldHaveContent(Page page, string regex, string flags, string because)
         {
-            throw Exception($"Expected page to have content \"{regex}\"", "but it did not", because);
+            throw Exception($"Expected page to have content \"/{regex}/{flags}\"", "but it did not", because);
         }
 
-        public static void ShouldNotHaveContent(Page page, string regex, string because)
+        public static void ShouldNotHaveContent(Page page, string regex, string flags, string because)
         {
-            throw Exception($"Expected page not to have content \"{regex}\"", null, because);
+            throw Exception($"Expected page not to have content \"/{regex}/{flags}\"", null, because);
         }
 
-        public static void ShouldHaveTitle(Page page, string regex, string actual, string because)
+        public static void ShouldHaveTitle(Page page, string regex, string flags, string actual, string because)
         {
-            throw Exception($"Expected page to have title \"{regex}\"", $"but found \"{actual}\"", because);
+            throw Exception($"Expected page to have title \"/{regex}/{flags}\"", $"but found \"{actual}\"", because);
         }
 
-        public static void ShouldNotHaveTitle(Page page, string regex, string because)
+        public static void ShouldNotHaveTitle(Page page, string regex, string flags, string because)
         {
-            throw Exception($"Expected page not to have title \"{regex}\"", null, because);
+            throw Exception($"Expected page not to have title \"/{regex}/{flags}\"", null, because);
         }
 
         /* ElementHandle */
@@ -56,14 +56,14 @@ namespace PuppeteerSharp.Contrib.Should
             throw Exception($"Expected element not to have attribute \"{name}\"", "but it did", because);
         }
 
-        public static void ShouldHaveContent(ElementHandle elementHandle, string content, string because)
+        public static void ShouldHaveContent(ElementHandle elementHandle, string regex, string flags, string because)
         {
-            throw Exception($"Expected element to have content \"{content}\"", "but it did not", because);
+            throw Exception($"Expected element to have content \"/{regex}/{flags}\"", "but it did not", because);
         }
 
-        public static void ShouldNotHaveContent(ElementHandle elementHandle, string content, string because)
+        public static void ShouldNotHaveContent(ElementHandle elementHandle, string regex, string flags, string because)
         {
-            throw Exception($"Expected element not to have content \"{content}\"", "but it did", because);
+            throw Exception($"Expected element not to have content \"/{regex}/{flags}\"", "but it did", because);
         }
 
         public static void ShouldHaveClass(ElementHandle elementHandle, string className, string because)

--- a/tests/PuppeteerSharp.Contrib.Tests/Extensions/ElementHandleExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/Extensions/ElementHandleExtensionsTests.cs
@@ -29,6 +29,9 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
             var bar = await html.QuerySelectorWithContentAsync("div", "Ba.");
             Assert.Equal("bar", await bar.IdAsync());
 
+            var flags = await html.QuerySelectorWithContentAsync("div", "foo", "i");
+            Assert.Equal("foo", await flags.IdAsync());
+
             var missing = await html.QuerySelectorWithContentAsync("div", "Missing");
             Assert.Null(missing);
         }
@@ -50,6 +53,9 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
 
             divs = await html.QuerySelectorAllWithContentAsync("div", "Ba.");
             Assert.Equal(new[] { "bar", "baz" }, await Task.WhenAll(divs.Select(x => x.IdAsync())));
+
+            var flags = await html.QuerySelectorAllWithContentAsync("div", "foo", "i");
+            Assert.Equal(new[] { "foo" }, await Task.WhenAll(flags.Select(x => x.IdAsync())));
 
             var missing = await html.QuerySelectorAllWithContentAsync("div", "Missing");
             Assert.Empty(missing);
@@ -108,11 +114,21 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
         [Fact]
         public async Task HasContentAsync_should_return_true_if_element_has_the_content()
         {
-            var like = await Page.QuerySelectorAsync(".like");
-            Assert.True(await like.HasContentAsync("100"));
+            await Page.SetContentAsync(@"
+<html>
+  <div id='foo'>Foo</div>
+  <div id='bar'>Bar</div>
+  <div id='baz'>Baz</div>
+</html>");
 
-            var retweets = await Page.QuerySelectorAsync("div");
-            Assert.False(await retweets.HasContentAsync("20"));
+            var foo = await Page.QuerySelectorAsync("#foo");
+            Assert.True(await foo.HasContentAsync("Foo"));
+
+            var bar = await Page.QuerySelectorAsync("#bar");
+            Assert.False(await bar.HasContentAsync("ba."));
+
+            var flags = await Page.QuerySelectorAsync("html");
+            Assert.True(await flags.HasContentAsync("ba.", "i"));
 
             var missing = await Page.QuerySelectorAsync(".missing");
             await Assert.ThrowsAsync<ArgumentNullException>(() => missing.HasContentAsync(""));

--- a/tests/PuppeteerSharp.Contrib.Tests/Extensions/PageExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/Extensions/PageExtensionsTests.cs
@@ -25,6 +25,9 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
             var bar = await Page.QuerySelectorWithContentAsync("div", "Ba.");
             Assert.Equal("bar", await bar.IdAsync());
 
+            var flags = await Page.QuerySelectorWithContentAsync("div", "foo", "i");
+            Assert.Equal("foo", await flags.IdAsync());
+
             var missing = await Page.QuerySelectorWithContentAsync("div", "Missing");
             Assert.Null(missing);
 
@@ -40,6 +43,9 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
             divs = await Page.QuerySelectorAllWithContentAsync("div", "Ba.");
             Assert.Equal(new[] { "bar", "baz" }, await Task.WhenAll(divs.Select(x => x.IdAsync())));
 
+            var flags = await Page.QuerySelectorAllWithContentAsync("div", "foo", "i");
+            Assert.Equal(new[] { "foo" }, await Task.WhenAll(flags.Select(x => x.IdAsync())));
+
             var missing = await Page.QuerySelectorAllWithContentAsync("div", "Missing");
             Assert.Empty(missing);
 
@@ -50,6 +56,7 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
         public async Task HasContentAsync_should_return_true_if_page_has_the_content()
         {
             Assert.True(await Page.HasContentAsync("Ba."));
+            Assert.True(await Page.HasContentAsync("ba.", "i"));
             Assert.False(await Page.HasContentAsync("Missing"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => ((Page)null).HasContentAsync(""));
         }
@@ -65,6 +72,7 @@ namespace PuppeteerSharp.Contrib.Tests.Extensions
 </html>");
 
             Assert.True(await Page.HasTitleAsync("Ba."));
+            Assert.True(await Page.HasTitleAsync("ba.", "i"));
             Assert.False(await Page.HasTitleAsync("Missing"));
             await Assert.ThrowsAsync<ArgumentNullException>(() => ((Page)null).HasTitleAsync(""));
         }

--- a/tests/PuppeteerSharp.Contrib.Tests/Should/ElementHandleShouldExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/Should/ElementHandleShouldExtensionsTests.cs
@@ -106,8 +106,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
             var like = await Page.QuerySelectorAsync(".like");
             await like.ShouldHaveContentAsync("100");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => like.ShouldHaveContentAsync("200"));
-            Assert.Equal("Expected element to have content \"200\", but it did not.", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => like.ShouldHaveContentAsync("200", "i"));
+            Assert.Equal("Expected element to have content \"/200/i\", but it did not.", ex.Message);
 
             var missing = await Page.QuerySelectorAsync(".missing");
             await Assert.ThrowsAsync<ArgumentNullException>(() => missing.ShouldHaveContentAsync(""));
@@ -119,8 +119,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
             var like = await Page.QuerySelectorAsync(".like");
             await like.ShouldNotHaveContentAsync("200");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => like.ShouldNotHaveContentAsync("100"));
-            Assert.Equal("Expected element not to have content \"100\", but it did.", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => like.ShouldNotHaveContentAsync("100", "i"));
+            Assert.Equal("Expected element not to have content \"/100/i\", but it did.", ex.Message);
 
             var missing = await Page.QuerySelectorAsync(".missing");
             await Assert.ThrowsAsync<ArgumentNullException>(() => missing.ShouldNotHaveContentAsync(""));

--- a/tests/PuppeteerSharp.Contrib.Tests/Should/PageShouldExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/Should/PageShouldExtensionsTests.cs
@@ -15,8 +15,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
         {
             await Page.ShouldHaveContentAsync("10.");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldHaveContentAsync("20."));
-            Assert.Equal("Expected page to have content \"20.\", but it did not.", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldHaveContentAsync("20.", "i"));
+            Assert.Equal("Expected page to have content \"/20./i\", but it did not.", ex.Message);
         }
 
         [Fact]
@@ -24,8 +24,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
         {
             await Page.ShouldNotHaveContentAsync("20.");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldNotHaveContentAsync("10."));
-            Assert.Equal("Expected page not to have content \"10.\".", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldNotHaveContentAsync("10.", "i"));
+            Assert.Equal("Expected page not to have content \"/10./i\".", ex.Message);
         }
 
         [Fact]
@@ -35,8 +35,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
 
             await Page.ShouldHaveTitleAsync("10.");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldHaveTitleAsync("20."));
-            Assert.Equal("Expected page to have title \"20.\", but found \"100\".", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldHaveTitleAsync("20.", "i"));
+            Assert.Equal("Expected page to have title \"/20./i\", but found \"100\".", ex.Message);
         }
 
         [Fact]
@@ -46,8 +46,8 @@ namespace PuppeteerSharp.Contrib.Tests.Should
 
             await Page.ShouldNotHaveTitleAsync("20.");
 
-            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldNotHaveTitleAsync("10."));
-            Assert.Equal("Expected page not to have title \"10.\".", ex.Message);
+            var ex = await Assert.ThrowsAsync<ShouldException>(() => Page.ShouldNotHaveTitleAsync("10.", "i"));
+            Assert.Equal("Expected page not to have title \"/10./i\".", ex.Message);
         }
     }
 }

--- a/tests/PuppeteerSharp.Contrib.Tests/Unsafe/Extensions/ElementHandleExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/Unsafe/Extensions/ElementHandleExtensionsTests.cs
@@ -71,13 +71,23 @@ namespace PuppeteerSharp.Contrib.Tests.Unsafe.Extensions
         [Fact]
         public async Task HasContent_should_return_true_if_element_has_the_content()
         {
-            var retweets = await Page.QuerySelectorAsync(".retweets");
-            Assert.True(retweets.HasContent("10"));
+            await Page.SetContentAsync(@"
+<html>
+  <div id='foo'>Foo</div>
+  <div id='bar'>Bar</div>
+  <div id='baz'>Baz</div>
+</html>");
 
-            Assert.True(Page.QuerySelectorAsync(".retweets").HasContent("10"));
+            var foo = await Page.QuerySelectorAsync("#foo");
+            Assert.True(foo.HasContent("Foo"));
 
-            retweets = await Page.QuerySelectorAsync("div");
-            Assert.False(retweets.HasContent("20"));
+            Assert.True(Page.QuerySelectorAsync("#foo").HasContent("Foo"));
+
+            var bar = await Page.QuerySelectorAsync("#bar");
+            Assert.False(bar.HasContent("ba."));
+
+            var flags = await Page.QuerySelectorAsync("html");
+            Assert.True(flags.HasContent("ba.", "i"));
 
             var missing = await Page.QuerySelectorAsync(".missing");
             Assert.Throws<ArgumentNullException>(() => missing.HasContent(""));


### PR DESCRIPTION
> To make this a bit more extraordinary, extend the regex with flags 🎏 
> this includes some breaking changes 💥

**Flags**

Extension methods that previously had a `regex` string parameter, now also has a `flags` string parameter.

* Extension methods for `ElementHandle`
  * `QuerySelectorWithContentAsync`
  * `QuerySelectorAllWithContentAsync`

* Extension methods for `Page`
  * `QuerySelectorWithContentAsync`
  * `QuerySelectorAllWithContentAsync`
  * `HasContentAsync`
  * `HasTitleAsync`
  * `ShouldHaveContentAsync`
  * `ShouldNotHaveContentAsync`
  * `ShouldHaveTitleAsync`
  * `ShouldNotHaveTitleAsync`

**Regex and Flags**

The extension methods for content on `ElementHandle`, now has `regex` and `flags` string parameters. :boom:

* Extension methods for `ElementHandle`
  * `HasContentAsync`
  * `ShouldHaveContentAsync`
  * `ShouldNotHaveContentAsync`

**Further reading**

Valid combinations of [flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp#Parameters):

* `g`
* `i`
* `m`
* `s`
* `u`
* `y`