### PR TITLE
Fix Interfaces for public API

### DIFF
--- a/samples/PuppeteerSharp.Contrib.Sample.MSTest/PuppeteerSharp.Contrib.Sample.MSTest.csproj
+++ b/samples/PuppeteerSharp.Contrib.Sample.MSTest/PuppeteerSharp.Contrib.Sample.MSTest.csproj
@@ -11,8 +11,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.Should" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.Should\PuppeteerSharp.Contrib.Should.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/PuppeteerSharp.Contrib.Sample.MSTest/PuppeteerSharpRepoTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.MSTest/PuppeteerSharpRepoTests.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Contrib.Sample
     [TestClass]
     public class PuppeteerSharpRepoTests
     {
-        private Browser Browser { get; set; }
+        private IBrowser Browser { get; set; }
 
         [TestInitialize]
         public async Task TestInitialize()

--- a/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/.editorconfig
+++ b/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/.editorconfig
@@ -4,5 +4,6 @@
 root = false
 
 [*.cs]
+dotnet_diagnostic.IDE0044.severity = none
 dotnet_diagnostic.IDE0052.severity = none
 dotnet_diagnostic.IDE1006.severity = none

--- a/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/PuppeteerSharp.Contrib.Sample.Machine.Specifications.csproj
+++ b/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/PuppeteerSharp.Contrib.Sample.Machine.Specifications.csproj
@@ -5,7 +5,6 @@
     <Nullable>disable</Nullable>
     <RootNamespace>PuppeteerSharp.Contrib.Sample</RootNamespace>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);IDE0044</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,8 +12,10 @@
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.2" />
     <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.Should" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.Should\PuppeteerSharp.Contrib.Should.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/PuppeteerSharpRepoSpecs.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.Machine.Specifications/PuppeteerSharpRepoSpecs.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Contrib.Sample
     [Subject("PuppeteerSharp")]
     public class PuppeteerSharpRepoSpecs
     {
-        static Browser Browser;
+        static IBrowser Browser;
 
         Establish context = async () =>
         {

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/ExtensionsTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/ExtensionsTests.cs
@@ -7,8 +7,8 @@ namespace PuppeteerSharp.Contrib.Sample
 {
     public class ExtensionsTests
     {
-        Browser Browser { get; set; }
-        Page Page { get; set; }
+        IBrowser Browser { get; set; }
+        IPage Page { get; set; }
 
         [SetUp]
         public async Task SetUp()

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/PageObjects.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/PageObjects.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp.Contrib.Sample
     public class GitHubStartPage : PageObject
     {
         [Selector("main h1")]
-        public virtual Task<ElementHandle> Heading { get; }
+        public virtual Task<IElementHandle> Heading { get; }
 
         [Selector("header")]
         public virtual Task<GitHubHeader> Header { get; }
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Contrib.Sample
     public class GitHubHeader : ElementObject
     {
         [Selector("#query-builder-test")]
-        public virtual Task<ElementHandle> SearchInput { get; }
+        public virtual Task<IElementHandle> SearchInput { get; }
 
         public async Task SearchAsync(string text)
         {
@@ -57,19 +57,19 @@ namespace PuppeteerSharp.Contrib.Sample
     public class GitHubRepoListItem : ElementObject
     {
         [Selector("a")]
-        public virtual Task<ElementHandle> Link { get; }
+        public virtual Task<IElementHandle> Link { get; }
 
         [Selector("h3 + div")]
-        public virtual Task<ElementHandle> Text { get; }
+        public virtual Task<IElementHandle> Text { get; }
     }
 
     public class GitHubRepoPage : PageObject
     {
         [Selector("article > h1")]
-        public virtual Task<ElementHandle> Heading { get; }
+        public virtual Task<IElementHandle> Heading { get; }
 
         [Selector("#actions-tab")]
-        public virtual Task<ElementHandle> Actions { get; }
+        public virtual Task<IElementHandle> Actions { get; }
 
         public async Task<GitHubActionsPage> GotoActionsAsync()
         {

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharp.Contrib.Sample.NUnit.csproj
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharp.Contrib.Sample.NUnit.csproj
@@ -11,9 +11,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.PageObjects" Version="5.0.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.Should" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.PageObjects\PuppeteerSharp.Contrib.PageObjects.csproj" />
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.Should\PuppeteerSharp.Contrib.Should.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharpRepoPageObjectTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharpRepoPageObjectTests.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp.Contrib.Sample
 {
     public class PuppeteerSharpRepoPageObjectTests
     {
-        private Browser Browser { get; set; }
+        private IBrowser Browser { get; set; }
 
         [SetUp]
         public async Task SetUp()

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharpRepoTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/PuppeteerSharpRepoTests.cs
@@ -9,7 +9,7 @@ namespace PuppeteerSharp.Contrib.Sample
 {
     public class PuppeteerSharpRepoTests
     {
-        private Browser Browser { get; set; }
+        private IBrowser Browser { get; set; }
 
         [SetUp]
         public async Task SetUp()

--- a/samples/PuppeteerSharp.Contrib.Sample.NUnit/ShouldTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.NUnit/ShouldTests.cs
@@ -6,8 +6,8 @@ namespace PuppeteerSharp.Contrib.Sample
 {
     public class ShouldTests
     {
-        Browser Browser { get; set; }
-        Page Page { get; set; }
+        IBrowser Browser { get; set; }
+        IPage Page { get; set; }
 
         [SetUp]
         public async Task SetUp()

--- a/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/Hooks.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/Hooks.cs
@@ -8,7 +8,7 @@ namespace PuppeteerSharp.Contrib.Sample
     public class Hooks(IObjectContainer objectContainer)
     {
         private IObjectContainer ObjectContainer { get; } = objectContainer;
-        private Browser Browser { get; set; }
+        private IBrowser Browser { get; set; }
 
         [BeforeScenario]
         public async Task BeforeScenario()

--- a/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/PuppeteerSharp.Contrib.Sample.SpecFlow.csproj
+++ b/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/PuppeteerSharp.Contrib.Sample.SpecFlow.csproj
@@ -10,13 +10,15 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.Should" Version="5.0.0" />
     <PackageReference Include="SpecFlow.xUnit" Version="3.9.74" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.Should\PuppeteerSharp.Contrib.Should.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/StepDefinitions/PuppeteerSharpRepoSteps.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.SpecFlow/StepDefinitions/PuppeteerSharpRepoSteps.cs
@@ -12,8 +12,8 @@ namespace PuppeteerSharp.Contrib.Sample.StepDefinitions
     [Binding]
     public class PuppeteerSharpRepoSteps(Browser browser)
     {
-        private Browser Browser { get; } = browser;
-        private Page Page { get; set; }
+        private IBrowser Browser { get; } = browser;
+        private IPage Page { get; set; }
         private Dictionary<string, string> LatestReleaseVersion { get; } = new Dictionary<string, string>();
 
         [BeforeScenario]

--- a/samples/PuppeteerSharp.Contrib.Sample.Xunit/Examples.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.Xunit/Examples.cs
@@ -6,8 +6,8 @@ namespace PuppeteerSharp.Documentation
 {
     public class Examples : IAsyncLifetime
     {
-        private Browser _browser;
-        private Page _page;
+        private IBrowser _browser;
+        private IPage _page;
 
         public async Task InitializeAsync()
         {

--- a/samples/PuppeteerSharp.Contrib.Sample.Xunit/Examples.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.Xunit/Examples.cs
@@ -81,7 +81,6 @@ namespace PuppeteerSharp.Documentation
             await _page.WaitForExpressionAsync("1 + 1 === 2", new WaitForFunctionOptions { Timeout = timeout });
             await _page.WaitForFunctionAsync("() => window.location.href === 'https://github.com/hardkoded/puppeteer-sharp'", new WaitForFunctionOptions { Timeout = timeout });
             await _page.WaitForSelectorAsync("#readme", new WaitForSelectorOptions { Timeout = timeout });
-            await _page.WaitForXPathAsync("//*[@id='readme']", new WaitForSelectorOptions { Timeout = timeout });
             await _page.WaitForTimeoutAsync(timeout);
 
             // WaitUntilNavigation
@@ -99,7 +98,6 @@ namespace PuppeteerSharp.Documentation
             await frame.WaitForExpressionAsync("1 + 1 === 2", new WaitForFunctionOptions { Timeout = timeout });
             await frame.WaitForFunctionAsync("() => window.location.href === 'https://github.com/hardkoded/puppeteer-sharp'", new WaitForFunctionOptions { Timeout = timeout });
             await frame.WaitForSelectorAsync("#readme", new WaitForSelectorOptions { Timeout = timeout });
-            await frame.WaitForXPathAsync("//*[@id='readme']", new WaitForSelectorOptions { Timeout = timeout });
             await frame.WaitForTimeoutAsync(timeout);
         }
 

--- a/samples/PuppeteerSharp.Contrib.Sample.Xunit/PuppeteerSharp.Contrib.Sample.Xunit.csproj
+++ b/samples/PuppeteerSharp.Contrib.Sample.Xunit/PuppeteerSharp.Contrib.Sample.Xunit.csproj
@@ -9,13 +9,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
-    <PackageReference Include="PuppeteerSharp.Contrib.Should" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.6.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PuppeteerSharp.Contrib.Should\PuppeteerSharp.Contrib.Should.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/PuppeteerSharp.Contrib.Sample.Xunit/PuppeteerSharpRepoTests.cs
+++ b/samples/PuppeteerSharp.Contrib.Sample.Xunit/PuppeteerSharpRepoTests.cs
@@ -9,7 +9,7 @@ namespace PuppeteerSharp.Contrib.Sample
 {
     public class PuppeteerSharpRepoTests : IAsyncLifetime
     {
-        private Browser Browser { get; set; }
+        private IBrowser Browser { get; set; }
 
         public async Task InitializeAsync()
         {

--- a/src/PuppeteerSharp.Contrib.Extensions/ElementHandleAttributeExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/ElementHandleAttributeExtensions.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 namespace PuppeteerSharp.Contrib.Extensions
 {
     /// <summary>
-    /// Extension methods for accessing attributes on <see cref="ElementHandle"/>.
+    /// Extension methods for accessing attributes on <see cref="IElementHandle"/>.
     /// </summary>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes"/>
     public static class ElementHandleAttributeExtensions
@@ -11,9 +11,9 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Id of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>id</c>, or <c>null</c> if the attribute is missing.</returns>
-        public static async Task<string> IdAsync(this ElementHandle elementHandle)
+        public static async Task<string> IdAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetAttributeAsync("id").ConfigureAwait(false);
         }
@@ -21,10 +21,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Name of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>name</c>, or <c>null</c> if the attribute is missing.</returns>
         /// <remarks><![CDATA[Elements: <button>, <form>, <fieldset>, <iframe>, <input>, <keygen>, <object>, <output>, <select>, <textarea>, <map>, <meta>, <param>]]></remarks>
-        public static async Task<string> NameAsync(this ElementHandle elementHandle)
+        public static async Task<string> NameAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetAttributeAsync("name").ConfigureAwait(false);
         }
@@ -32,10 +32,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Value of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>value</c>, or <c>null</c> if the attribute is missing.</returns>
         /// <remarks><![CDATA[Elements: <button>, <option>, <input>, <li>, <meter>, <progress>, <param>]]></remarks>
-        public static async Task<string> ValueAsync(this ElementHandle elementHandle)
+        public static async Task<string> ValueAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetAttributeAsync("value").ConfigureAwait(false);
         }
@@ -43,10 +43,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Href of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>href</c>, or <c>null</c> if the attribute is missing.</returns>
         /// <remarks><![CDATA[Elements: <a>, <area>, <base>, <link>]]></remarks>
-        public static async Task<string> HrefAsync(this ElementHandle elementHandle)
+        public static async Task<string> HrefAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetAttributeAsync("href").ConfigureAwait(false);
         }
@@ -54,10 +54,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Src of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>src</c>, or <c>null</c> if the attribute is missing.</returns>
         /// <remarks><![CDATA[Elements: <audio>, <embed>, <iframe>, <img>, <input>, <script>, <source>, <track>, <video>]]></remarks>
-        public static async Task<string> SrcAsync(this ElementHandle elementHandle)
+        public static async Task<string> SrcAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetAttributeAsync("src").ConfigureAwait(false);
         }
@@ -65,11 +65,11 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element has the specified attribute or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="name">The attribute name.</param>
         /// <returns><c>true</c> if the element has the specified attribute.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/hasAttribute"/>
-        public static async Task<bool> HasAttributeAsync(this ElementHandle elementHandle, string name)
+        public static async Task<bool> HasAttributeAsync(this IElementHandle elementHandle, string name)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("(element, name) => element.hasAttribute(name)", name).ConfigureAwait(false);
         }
@@ -77,11 +77,11 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// The value of a specified attribute on the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="name">The attribute name.</param>
         /// <returns>The attribute value.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute"/>
-        public static async Task<string> GetAttributeAsync(this ElementHandle elementHandle, string name)
+        public static async Task<string> GetAttributeAsync(this IElementHandle elementHandle, string name)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<string>("(element, name) => element.getAttribute(name)", name).ConfigureAwait(false);
         }

--- a/src/PuppeteerSharp.Contrib.Extensions/ElementHandleExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/ElementHandleExtensions.cs
@@ -7,20 +7,20 @@ using Newtonsoft.Json.Linq;
 namespace PuppeteerSharp.Contrib.Extensions
 {
     /// <summary>
-    /// Extension methods for <see cref="ElementHandle"/>.
+    /// Extension methods for <see cref="IElementHandle"/>.
     /// </summary>
     public static class ElementHandleExtensions
     {
         /// <summary>
         /// The method runs <c>element.querySelectorAll</c> and then tests a <c>RegExp</c> against the elements <c>textContent</c>. The first element match is returned. If no element matches the selector and regular expression, the return value resolve to <c>null</c>.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/> to query.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/> to query.</param>
         /// <param name="selector">A selector to query element for.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
-        /// <returns>Task which resolves to <see cref="ElementHandle"/> pointing to the element.</returns>
+        /// <returns>Task which resolves to <see cref="IElementHandle"/> pointing to the element.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<ElementHandle?> QuerySelectorWithContentAsync(this ElementHandle elementHandle, string selector, string regex, string flags = "")
+        public static async Task<IElementHandle?> QuerySelectorWithContentAsync(this IElementHandle elementHandle, string selector, string regex, string flags = "")
         {
             return await elementHandle.GuardFromNull().EvaluateFunctionHandleAsync(
                 @"(element, selector, regex, flags) => {
@@ -31,19 +31,19 @@ namespace PuppeteerSharp.Contrib.Extensions
                 }",
                 selector,
                 regex,
-                flags).ConfigureAwait(false) as ElementHandle;
+                flags).ConfigureAwait(false) as IElementHandle;
         }
 
         /// <summary>
         /// The method runs <c>element.querySelectorAll</c> and then tests a <c>RegExp</c> against the elements <c>textContent</c>. All element matches are returned. If no element matches the selector and regular expression, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/> to query.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/> to query.</param>
         /// <param name="selector">A selector to query element for.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <returns>Task which resolves to ElementHandles pointing to the elements.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this ElementHandle elementHandle, string selector, string regex, string flags = "")
+        public static async Task<IElementHandle[]> QuerySelectorAllWithContentAsync(this IElementHandle elementHandle, string selector, string regex, string flags = "")
         {
             var arrayHandle = await elementHandle.GuardFromNull().EvaluateFunctionHandleAsync(
                 @"(element, selector, regex, flags) => {
@@ -58,15 +58,15 @@ namespace PuppeteerSharp.Contrib.Extensions
             var properties = await arrayHandle.GetPropertiesAsync().ConfigureAwait(false);
             await arrayHandle.DisposeAsync().ConfigureAwait(false);
 
-            return properties.Values.OfType<ElementHandle>().ToArray();
+            return properties.Values.OfType<IElementHandle>().ToArray();
         }
 
         /// <summary>
-        /// Indicates whether the element exists or not. A non null <see cref="ElementHandle"/> is considered existing.
+        /// Indicates whether the element exists or not. A non null <see cref="IElementHandle"/> is considered existing.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element exists.</returns>
-        public static bool Exists(this ElementHandle elementHandle)
+        public static bool Exists(this IElementHandle elementHandle)
         {
             return elementHandle != null;
         }
@@ -74,10 +74,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// InnerHtml of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>innerHTML</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML"/>
-        public static async Task<string> InnerHtmlAsync(this ElementHandle elementHandle)
+        public static async Task<string> InnerHtmlAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetPropertyValueAsync("innerHTML").ConfigureAwait(false);
         }
@@ -85,10 +85,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// OuterHtml of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>outerHTML</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/outerHTML"/>
-        public static async Task<string> OuterHtmlAsync(this ElementHandle elementHandle)
+        public static async Task<string> OuterHtmlAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetPropertyValueAsync("outerHTML").ConfigureAwait(false);
         }
@@ -96,10 +96,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// TextContent of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>textContent</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent"/>
-        public static async Task<string> TextContentAsync(this ElementHandle elementHandle)
+        public static async Task<string> TextContentAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetPropertyValueAsync("textContent").ConfigureAwait(false);
         }
@@ -107,10 +107,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// InnerText of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>innerText</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/innerText"/>
-        public static async Task<string> InnerTextAsync(this ElementHandle elementHandle)
+        public static async Task<string> InnerTextAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.GetPropertyValueAsync("innerText").ConfigureAwait(false);
         }
@@ -118,12 +118,12 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element has the specified content or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <returns><c>true</c> if the element has the specified content.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<bool> HasContentAsync(this ElementHandle elementHandle, string regex, string flags = "")
+        public static async Task<bool> HasContentAsync(this IElementHandle elementHandle, string regex, string flags = "")
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("(element, regex, flags) => RegExp(regex, flags).test(element.textContent)", regex, flags).ConfigureAwait(false);
         }
@@ -131,10 +131,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// ClassName of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>className</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/className"/>
-        public static async Task<string> ClassNameAsync(this ElementHandle elementHandle)
+        public static async Task<string> ClassNameAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<string>("element => element.className").ConfigureAwait(false);
         }
@@ -142,23 +142,23 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// ClassList of the element.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns>The element's <c>classList</c>.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/Element/classList"/>
-        public static async Task<string[]> ClassListAsync(this ElementHandle elementHandle)
+        public static async Task<string[]> ClassListAsync(this IElementHandle elementHandle)
         {
             var json = await elementHandle.EvaluateFunctionWithoutDisposeAsync<JObject>("element => element.classList").ConfigureAwait(false);
             var dictionary = json.ToObject<Dictionary<string, string>>();
-            return dictionary.Values.ToArray();
+            return dictionary?.Values.ToArray() ?? new string[0];
         }
 
         /// <summary>
         /// Indicates whether the element has the specified class or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="className">The class name.</param>
         /// <returns><c>true</c> if the element has the specified class.</returns>
-        public static async Task<bool> HasClassAsync(this ElementHandle elementHandle, string className)
+        public static async Task<bool> HasClassAsync(this IElementHandle elementHandle, string className)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("(element, className) => element.classList.contains(className)", className).ConfigureAwait(false);
         }
@@ -166,10 +166,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is visible or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is visible.</returns>
         /// <seealso href="https://blog.jquery.com/2009/02/20/jquery-1-3-2-released/#visible-hidden-overhauled"/>
-        public static async Task<bool> IsVisibleAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsVisibleAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.offsetWidth > 0 && element.offsetHeight > 0").ConfigureAwait(false);
         }
@@ -177,9 +177,9 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is hidden or not. This is the logical negation of <see cref="IsVisibleAsync"/>.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is hidden.</returns>
-        public static async Task<bool> IsHiddenAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsHiddenAsync(this IElementHandle elementHandle)
         {
             return !await elementHandle.IsVisibleAsync().ConfigureAwait(false);
         }
@@ -187,10 +187,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is selected or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is selected.</returns>
         /// <remarks><![CDATA[Elements: <option>]]></remarks>
-        public static async Task<bool> IsSelectedAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsSelectedAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.selected").ConfigureAwait(false);
         }
@@ -198,10 +198,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is checked or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is checked.</returns>
         /// <remarks><![CDATA[Elements: <command>, <input>]]></remarks>
-        public static async Task<bool> IsCheckedAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsCheckedAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.checked").ConfigureAwait(false);
         }
@@ -209,10 +209,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is disabled or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is disabled.</returns>
         /// <remarks><![CDATA[Elements: <button>, <command>, <fieldset>, <input>, <keygen>, <optgroup>, <option>, <select>, <textarea>]]></remarks>
-        public static async Task<bool> IsDisabledAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsDisabledAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.disabled").ConfigureAwait(false);
         }
@@ -220,10 +220,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is enabled or not. This is the logical negation of <see cref="IsDisabledAsync"/>.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is enabled.</returns>
         /// <remarks><![CDATA[Elements: <button>, <command>, <fieldset>, <input>, <keygen>, <optgroup>, <option>, <select>, <textarea>]]></remarks>
-        public static async Task<bool> IsEnabledAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsEnabledAsync(this IElementHandle elementHandle)
         {
             return !await elementHandle.IsDisabledAsync().ConfigureAwait(false);
         }
@@ -231,10 +231,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is read-only or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is read-only.</returns>
         /// <remarks><![CDATA[Elements: <input>, <textarea>]]></remarks>
-        public static async Task<bool> IsReadOnlyAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsReadOnlyAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.readOnly").ConfigureAwait(false);
         }
@@ -242,10 +242,10 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element is required or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element is required.</returns>
         /// <remarks><![CDATA[Elements: <input>, <select>, <textarea>]]></remarks>
-        public static async Task<bool> IsRequiredAsync(this ElementHandle elementHandle)
+        public static async Task<bool> IsRequiredAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element.required").ConfigureAwait(false);
         }
@@ -253,16 +253,16 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the element has focus or not.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <returns><c>true</c> if the element has focus.</returns>
         /// <remarks><![CDATA[Elements: <button>, <input>, <keygen>, <select>, <textarea>]]></remarks>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement"/>
-        public static async Task<bool> HasFocusAsync(this ElementHandle elementHandle)
+        public static async Task<bool> HasFocusAsync(this IElementHandle elementHandle)
         {
             return await elementHandle.EvaluateFunctionWithoutDisposeAsync<bool>("element => element === document.activeElement").ConfigureAwait(false);
         }
 
-        private static async Task<string> GetPropertyValueAsync(this ElementHandle elementHandle, string propertyName)
+        private static async Task<string> GetPropertyValueAsync(this IElementHandle elementHandle, string propertyName)
         {
             var property = await elementHandle.GuardFromNull().GetPropertyAsync(propertyName).ConfigureAwait(false);
             return await property.JsonValueAsync<string>().ConfigureAwait(false);

--- a/src/PuppeteerSharp.Contrib.Extensions/InternalExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/InternalExtensions.cs
@@ -5,19 +5,19 @@ namespace PuppeteerSharp.Contrib.Extensions
 {
     internal static class InternalExtensions
     {
-        internal static async Task<T> EvaluateFunctionWithoutDisposeAsync<T>(this ElementHandle elementHandle, string pageFunction, params object[] args)
+        internal static async Task<T> EvaluateFunctionWithoutDisposeAsync<T>(this IElementHandle elementHandle, string pageFunction, params object[] args)
         {
             return await elementHandle.GuardFromNull().EvaluateFunctionAsync<T>(pageFunction, args).ConfigureAwait(false);
         }
 
-        internal static Page GuardFromNull(this Page page)
+        internal static IPage GuardFromNull(this IPage page)
         {
             if (page == null) throw new ArgumentNullException(nameof(page));
 
             return page;
         }
 
-        internal static ElementHandle GuardFromNull(this ElementHandle elementHandle)
+        internal static IElementHandle GuardFromNull(this IElementHandle elementHandle)
         {
             if (elementHandle == null) throw new ArgumentNullException(nameof(elementHandle));
 

--- a/src/PuppeteerSharp.Contrib.Extensions/PageExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Extensions/PageExtensions.cs
@@ -4,20 +4,20 @@ using System.Threading.Tasks;
 namespace PuppeteerSharp.Contrib.Extensions
 {
     /// <summary>
-    /// Extension methods for <see cref="Page"/>.
+    /// Extension methods for <see cref="IPage"/>.
     /// </summary>
     public static class PageExtensions
     {
         /// <summary>
         /// The method runs <c>document.querySelectorAll</c> within the page and then tests a <c>RegExp</c> against the elements <c>textContent</c>. The first element match is returned. If no element matches the selector and regular expression, the return value resolve to <c>null</c>.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/> to query.</param>
+        /// <param name="page">A <see cref="IPage"/> to query.</param>
         /// <param name="selector">A selector to query page for.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
-        /// <returns>Task which resolves to <see cref="ElementHandle"/> pointing to the frame element.</returns>
+        /// <returns>Task which resolves to <see cref="IElementHandle"/> pointing to the frame element.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<ElementHandle?> QuerySelectorWithContentAsync(this Page page, string selector, string regex, string flags = "")
+        public static async Task<IElementHandle?> QuerySelectorWithContentAsync(this IPage page, string selector, string regex, string flags = "")
         {
             return await page.GuardFromNull().EvaluateFunctionHandleAsync(
                 @"(selector, regex, flags) => {
@@ -28,19 +28,19 @@ namespace PuppeteerSharp.Contrib.Extensions
                 }",
                 selector,
                 regex,
-                flags).ConfigureAwait(false) as ElementHandle;
+                flags).ConfigureAwait(false) as IElementHandle;
         }
 
         /// <summary>
         /// The method runs <c>document.querySelectorAll</c> within the page and then tests a <c>RegExp</c> against the elements <c>textContent</c>. All element matches are returned. If no element matches the selector and regular expression, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/> to query.</param>
+        /// <param name="page">A <see cref="IPage"/> to query.</param>
         /// <param name="selector">A selector to query page for.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <returns>Task which resolves to ElementHandles pointing to the frame elements.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<ElementHandle[]> QuerySelectorAllWithContentAsync(this Page page, string selector, string regex, string flags = "")
+        public static async Task<IElementHandle[]> QuerySelectorAllWithContentAsync(this IPage page, string selector, string regex, string flags = "")
         {
             var arrayHandle = await page.GuardFromNull().EvaluateFunctionHandleAsync(
                 @"(selector, regex, flags) => {
@@ -56,18 +56,18 @@ namespace PuppeteerSharp.Contrib.Extensions
             var properties = await arrayHandle.GetPropertiesAsync().ConfigureAwait(false);
             await arrayHandle.DisposeAsync().ConfigureAwait(false);
 
-            return properties.Values.OfType<ElementHandle>().ToArray();
+            return properties.Values.OfType<IElementHandle>().ToArray();
         }
 
         /// <summary>
         /// Indicates whether the page has the specified content or not.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <returns><c>true</c> if the page has the specified content.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<bool> HasContentAsync(this Page page, string regex, string flags = "")
+        public static async Task<bool> HasContentAsync(this IPage page, string regex, string flags = "")
         {
             return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex, flags) => RegExp(regex, flags).test(document.documentElement.textContent)", regex, flags).ConfigureAwait(false);
         }
@@ -75,12 +75,12 @@ namespace PuppeteerSharp.Contrib.Extensions
         /// <summary>
         /// Indicates whether the page has the specified title or not.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.title</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <returns><c>true</c> if the page has the specified title.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task<bool> HasTitleAsync(this Page page, string regex, string flags = "")
+        public static async Task<bool> HasTitleAsync(this IPage page, string regex, string flags = "")
         {
             return await page.GuardFromNull().EvaluateFunctionAsync<bool>("(regex, flags) => RegExp(regex, flags).test(document.title)", regex, flags).ConfigureAwait(false);
         }

--- a/src/PuppeteerSharp.Contrib.Extensions/PuppeteerSharp.Contrib.Extensions.csproj
+++ b/src/PuppeteerSharp.Contrib.Extensions/PuppeteerSharp.Contrib.Extensions.csproj
@@ -30,7 +30,7 @@
   <Import Project="../../Analyzers.props" />
 
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
+    <PackageReference Include="PuppeteerSharp" Version="12.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/PuppeteerSharp.Contrib.PageObjects/Attributes/SelectorAttribute.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/Attributes/SelectorAttribute.cs
@@ -12,8 +12,8 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// </list>
     /// that returns a <see cref="System.Threading.Tasks.Task{TResult}"/> of:
     /// <list type="bullet">
-    /// <item><description><see cref="ElementHandle"/>,</description></item>
-    /// <item><description><see cref="ElementHandle"/>[],</description></item>
+    /// <item><description><see cref="IElementHandle"/>,</description></item>
+    /// <item><description><see cref="IElementHandle"/>[],</description></item>
     /// <item><description><see cref="ElementObject"/> or</description></item>
     /// <item><description><see cref="ElementObject"/>[]</description></item>
     /// </list>
@@ -23,10 +23,10 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// <code>
     /// <![CDATA[
     /// [Selector("#foo")]
-    /// public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+    /// public virtual Task<IElementHandle> SelectorForElementHandle { get; }
     ///
     /// [Selector(".bar")]
-    /// public virtual Task<ElementHandle[]> SelectorForElementHandleArray { get; }
+    /// public virtual Task<IElementHandle[]> SelectorForElementHandleArray { get; }
     ///
     /// [Selector("#foo")]
     /// public virtual Task<FooElementObject> SelectorForElementObject { get; }
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
     public sealed class SelectorAttribute(string selector) : Attribute
     {
         /// <summary>
-        /// A selector to query a <see cref="Page"/> or <see cref="ElementHandle"/> for.
+        /// A selector to query a <see cref="IPage"/> or <see cref="IElementHandle"/> for.
         /// </summary>
         public string Selector { get; } = selector;
     }

--- a/src/PuppeteerSharp.Contrib.PageObjects/Attributes/XPathAttribute.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/Attributes/XPathAttribute.cs
@@ -12,7 +12,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// </list>
     /// that returns a <see cref="System.Threading.Tasks.Task{TResult}"/> of:
     /// <list type="bullet">
-    /// <item><description><see cref="ElementHandle"/>[] or</description></item>
+    /// <item><description><see cref="IElementHandle"/>[] or</description></item>
     /// <item><description><see cref="ElementObject"/>[]</description></item>
     /// </list>
     /// </summary>
@@ -21,18 +21,19 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// <code>
     /// <![CDATA[
     /// [XPath("//div")]
-    /// public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+    /// public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
     ///
     /// [XPath("//div")]
     /// public virtual Task<FooElementObject[]> XPathForElementObjectArray { get; }
     /// ]]>
     /// </code>
     /// </example>
+    [Obsolete("Use " + nameof(SelectorAttribute) + " instead")]
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class XPathAttribute(string expression) : Attribute
     {
         /// <summary>
-        /// An XPath expression to evaluate on a <see cref="Page"/> or <see cref="ElementHandle"/>.
+        /// An XPath expression to evaluate on a <see cref="IPage"/> or <see cref="IElementHandle"/>.
         /// </summary>
         public string Expression { get; } = expression;
     }

--- a/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/InterceptorSelector.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/InterceptorSelector.cs
@@ -15,7 +15,9 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
                 return interceptors.Where(x => x is SelectorInterceptor).ToArray();
             }
 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (method.IsGetterPropertyWithAttribute<XPathAttribute>())
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 return interceptors.Where(x => x is XPathInterceptor).ToArray();
             }

--- a/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/InvocationExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/InvocationExtensions.cs
@@ -56,12 +56,12 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
 
             if (page == null) return null;
 
-            if (invocation.IsReturning<ElementHandle>())
+            if (invocation.IsReturning<IElementHandle>())
             {
                 return await page.QuerySelectorAsync(attribute.Selector).ConfigureAwait(false);
             }
 
-            if (invocation.IsReturning<ElementHandle[]>())
+            if (invocation.IsReturning<IElementHandle[]>())
             {
                 return await page.QuerySelectorAllAsync(attribute.Selector).ConfigureAwait(false);
             }
@@ -92,12 +92,12 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
 
             if (element == null) return null;
 
-            if (invocation.IsReturning<ElementHandle>())
+            if (invocation.IsReturning<IElementHandle>())
             {
                 return await element.QuerySelectorAsync(attribute.Selector).ConfigureAwait(false);
             }
 
-            if (invocation.IsReturning<ElementHandle[]>())
+            if (invocation.IsReturning<IElementHandle[]>())
             {
                 return await element.QuerySelectorAllAsync(attribute.Selector).ConfigureAwait(false);
             }
@@ -122,22 +122,28 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
             return null;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public static async Task<object?> GetReturnValueAsync(this IInvocation invocation, PageObject pageObject, XPathAttribute attribute)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             var page = pageObject.Page;
 
             if (page == null) return null;
 
-            if (invocation.IsReturning<ElementHandle[]>())
+            if (invocation.IsReturning<IElementHandle[]>())
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 return await page.XPathAsync(attribute.Expression).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (invocation.IsReturningElementObjectArray())
             {
                 var arrayType = invocation.Method.ReturnType.GetGenericArguments()[0];
                 var proxyType = arrayType.GetElementType();
+#pragma warning disable CS0618 // Type or member is obsolete
                 var elementHandles = await page.XPathAsync(attribute.Expression).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 return ProxyFactory.ElementObjectArray(proxyType, page, elementHandles);
             }
@@ -145,22 +151,28 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
             return null;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         public static async Task<object?> GetReturnValueAsync(this IInvocation invocation, ElementObject elementObject, XPathAttribute attribute)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             var element = elementObject.Element;
 
             if (element == null) return null;
 
-            if (invocation.IsReturning<ElementHandle[]>())
+            if (invocation.IsReturning<IElementHandle[]>())
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 return await element.XPathAsync(attribute.Expression).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             if (invocation.IsReturningElementObjectArray())
             {
                 var arrayType = invocation.Method.ReturnType.GetGenericArguments()[0];
                 var proxyType = arrayType.GetElementType();
+#pragma warning disable CS0618 // Type or member is obsolete
                 var elementHandles = await element.XPathAsync(attribute.Expression).ConfigureAwait(false);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 return ProxyFactory.ElementObjectArray(proxyType, elementObject.Page, elementHandles);
             }

--- a/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/ProxyFactory.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/ProxyFactory.cs
@@ -10,7 +10,7 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
         private static readonly ProxyGenerationOptions Options = new(new ProxyGenerationHook()) { Selector = new InterceptorSelector() };
 #pragma warning restore IDE1006 // Naming Styles
 
-        public static T PageObject<T>(Page page, Response response)
+        public static T PageObject<T>(IPage page, IResponse response)
             where T : PageObject
         {
             var proxy = ProxyGenerator.CreateClassProxy<T>(Options, new SelectorInterceptor(), new XPathInterceptor());
@@ -19,7 +19,7 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
             return proxy;
         }
 
-        public static T? ElementObject<T>(Page page, ElementHandle elementHandle)
+        public static T? ElementObject<T>(IPage page, IElementHandle elementHandle)
             where T : ElementObject
         {
             if (elementHandle == null) return default;
@@ -30,7 +30,7 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
             return proxy;
         }
 
-        public static ElementObject? ElementObject(Type proxyType, Page page, ElementHandle elementHandle)
+        public static ElementObject? ElementObject(Type proxyType, IPage page, IElementHandle elementHandle)
         {
             if (elementHandle == null) return default;
 
@@ -40,7 +40,7 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
             return proxy;
         }
 
-        public static Array ElementObjectArray(Type proxyType, Page page, ElementHandle[] elementHandles)
+        public static Array ElementObjectArray(Type proxyType, IPage page, IElementHandle[] elementHandles)
         {
             var array = Array.CreateInstance(proxyType, elementHandles.Length);
             for (var i = 0; i < elementHandles.Length; i++)

--- a/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/ProxyGenerationHook.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/ProxyGenerationHook.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Reflection;
 using Castle.DynamicProxy;
 
@@ -18,7 +18,9 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
         public bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
         {
             return (methodInfo.IsGetterPropertyWithAttribute<SelectorAttribute>() ||
+#pragma warning disable CS0618 // Type or member is obsolete
                     methodInfo.IsGetterPropertyWithAttribute<XPathAttribute>()) &&
+#pragma warning restore CS0618 // Type or member is obsolete
                     methodInfo.IsReturningAsyncResult();
         }
 

--- a/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/XPathInterceptor.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/DynamicProxy/XPathInterceptor.cs
@@ -28,9 +28,11 @@ namespace PuppeteerSharp.Contrib.PageObjects.DynamicProxy
 
         private static async Task InterceptAsync(IInvocation invocation)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (invocation.IsGetterPropertyWithAttribute<XPathAttribute>())
             {
                 var attribute = invocation.GetAttribute<XPathAttribute>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (invocation.InvocationTarget is PageObject pageObject)
                 {

--- a/src/PuppeteerSharp.Contrib.PageObjects/ElementObject.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/ElementObject.cs
@@ -11,10 +11,10 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// public class BarElementObject : ElementObject
     /// {
     ///     [Selector("#foo")]
-    ///     public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+    ///     public virtual Task<IElementHandle> SelectorForElementHandle { get; }
     ///
     ///     [Selector(".bar")]
-    ///     public virtual Task<ElementHandle[]> SelectorForElementHandleArray { get; }
+    ///     public virtual Task<IElementHandle[]> SelectorForElementHandleArray { get; }
     ///
     ///     [Selector("#foo")]
     ///     public virtual Task<FooElementObject> SelectorForElementObject { get; }
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
     ///     public virtual Task<BarElementObject[]> SelectorForElementObjectArray { get; }
     ///
     ///     [XPath("//div")]
-    ///     public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+    ///     public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
     ///
     ///     [XPath("//div")]
     ///     public virtual Task<FooElementObject[]> XPathForElementObjectArray { get; }
@@ -37,17 +37,17 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// The <c>PuppeteerSharp</c> page.
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public Page Page { get; private set; }
+        public IPage Page { get; private set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <summary>
         /// The <c>PuppeteerSharp</c> element handle.
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public ElementHandle Element { get; private set; }
+        public IElementHandle Element { get; private set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-        internal void Initialize(Page page, ElementHandle element)
+        internal void Initialize(IPage page, IElementHandle element)
         {
             Page = page;
             Element = element;

--- a/src/PuppeteerSharp.Contrib.PageObjects/ElementObject.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/ElementObject.cs
@@ -2,7 +2,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
 {
     /// <summary>
     /// <para>Base class for element objects.</para>
-    /// <para>Create element objects by inheriting <see cref="ElementObject"/> and declare properties decorated with <see cref="SelectorAttribute"/> or <see cref="XPathAttribute"/>.</para>
+    /// <para>Create element objects by inheriting <see cref="ElementObject"/> and declare properties decorated with <see cref="SelectorAttribute"/>.</para>
     /// </summary>
     /// <example>
     /// Usage:
@@ -21,12 +21,6 @@ namespace PuppeteerSharp.Contrib.PageObjects
     ///
     ///     [Selector(".bar")]
     ///     public virtual Task<BarElementObject[]> SelectorForElementObjectArray { get; }
-    ///
-    ///     [XPath("//div")]
-    ///     public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
-    ///
-    ///     [XPath("//div")]
-    ///     public virtual Task<FooElementObject[]> XPathForElementObjectArray { get; }
     /// }
     /// ]]>
     /// </code>
@@ -36,16 +30,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// <summary>
         /// The <c>PuppeteerSharp</c> page.
         /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public IPage Page { get; private set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public IPage Page { get; private set; } = null!;
 
         /// <summary>
         /// The <c>PuppeteerSharp</c> element handle.
         /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public IElementHandle Element { get; private set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public IElementHandle Element { get; private set; } = null!;
 
         internal void Initialize(IPage page, IElementHandle element)
         {

--- a/src/PuppeteerSharp.Contrib.PageObjects/Extensions/ElementHandleExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/Extensions/ElementHandleExtensions.cs
@@ -7,7 +7,7 @@ using PuppeteerSharp.Contrib.PageObjects.DynamicProxy;
 namespace PuppeteerSharp.Contrib.PageObjects
 {
     /// <summary>
-    /// <see cref="ElementHandle"/> extension methods.
+    /// <see cref="IElementHandle"/> extension methods.
     /// </summary>
     public static class ElementHandleExtensions
     {
@@ -16,11 +16,11 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the selector, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="elementHandle">A <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">A <see cref="IElementHandle"/>.</param>
         /// <param name="selector">A selector to query element for.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/> array.</returns>
-        /// <seealso cref="ElementHandle.QuerySelectorAllAsync(string)"/>
-        public static async Task<T[]> QuerySelectorAllAsync<T>(this ElementHandle elementHandle, string selector)
+        /// <seealso cref="IElementHandle.QuerySelectorAllAsync(string)"/>
+        public static async Task<T[]> QuerySelectorAllAsync<T>(this IElementHandle elementHandle, string selector)
             where T : ElementObject
         {
             var results = await elementHandle.GuardFromNull().QuerySelectorAllAsync(selector).ConfigureAwait(false);
@@ -33,11 +33,11 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the selector, the return value resolve to <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="elementHandle">A <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">A <see cref="IElementHandle"/>.</param>
         /// <param name="selector">A selector to query element for.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/>.</returns>
-        /// <seealso cref="ElementHandle.QuerySelectorAsync(string)"/>
-        public static async Task<T?> QuerySelectorAsync<T>(this ElementHandle elementHandle, string selector)
+        /// <seealso cref="IElementHandle.QuerySelectorAsync(string)"/>
+        public static async Task<T?> QuerySelectorAsync<T>(this IElementHandle elementHandle, string selector)
             where T : ElementObject
         {
             var result = await elementHandle.GuardFromNull().QuerySelectorAsync(selector).ConfigureAwait(false);
@@ -50,11 +50,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the expression, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="elementHandle">A <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">A <see cref="IElementHandle"/>.</param>
         /// <param name="expression">Expression to evaluate <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate"/>.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/> array.</returns>
-        /// <seealso cref="ElementHandle.XPathAsync(string)"/>
-        public static async Task<T[]> XPathAsync<T>(this ElementHandle elementHandle, string expression)
+        /// <seealso cref="IElementHandle.XPathAsync(string)"/>
+        [Obsolete("Use " + nameof(QuerySelectorAsync) + " instead")]
+        public static async Task<T[]> XPathAsync<T>(this IElementHandle elementHandle, string expression)
             where T : ElementObject
         {
             var results = await elementHandle.GuardFromNull().XPathAsync(expression).ConfigureAwait(false);
@@ -66,14 +67,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a selector to be added to the DOM and returns an <see cref="ElementObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="elementHandle">A <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">A <see cref="IElementHandle"/>.</param>
         /// <param name="selector">A selector of an element to wait for.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/>, when a element specified by selector string is added to DOM.
         /// Resolves to <c>null</c> if waiting for <c>hidden: true</c> and selector is not found in DOM.
         /// </returns>
-        /// <seealso cref="ElementHandle.WaitForSelectorAsync(string, WaitForSelectorOptions)"/>
-        public static async Task<T?> WaitForSelectorAsync<T>(this ElementHandle elementHandle, string selector, WaitForSelectorOptions? options = null)
+        /// <seealso cref="IElementHandle.WaitForSelectorAsync(string, WaitForSelectorOptions)"/>
+        public static async Task<T?> WaitForSelectorAsync<T>(this IElementHandle elementHandle, string selector, WaitForSelectorOptions? options = null)
             where T : ElementObject
         {
             var result = await elementHandle.GuardFromNull().WaitForSelectorAsync(selector, options).ConfigureAwait(false);
@@ -81,15 +82,15 @@ namespace PuppeteerSharp.Contrib.PageObjects
             return ProxyFactory.ElementObject<T>(elementHandle.GetPage(), result);
         }
 
-        private static Page GetPage(this ElementHandle elementHandle)
+        private static IPage GetPage(this IElementHandle elementHandle)
         {
-            var propertyInfo = elementHandle.GetType().GetProperty("Page", BindingFlags.NonPublic | BindingFlags.Instance);
+            var propertyInfo = elementHandle.GetType().GetProperty("IPage", BindingFlags.NonPublic | BindingFlags.Instance);
             var methodInfo = propertyInfo.GetGetMethod(nonPublic: true);
 
-            return (Page)methodInfo.Invoke(elementHandle, null);
+            return (IPage)methodInfo.Invoke(elementHandle, null);
         }
 
-        private static ElementHandle GuardFromNull(this ElementHandle elementHandle)
+        private static IElementHandle GuardFromNull(this IElementHandle elementHandle)
         {
             if (elementHandle == null) throw new ArgumentNullException(nameof(elementHandle));
 

--- a/src/PuppeteerSharp.Contrib.PageObjects/Extensions/ElementHandleExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/Extensions/ElementHandleExtensions.cs
@@ -84,7 +84,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
 
         private static IPage GetPage(this IElementHandle elementHandle)
         {
-            var propertyInfo = elementHandle.GetType().GetProperty("IPage", BindingFlags.NonPublic | BindingFlags.Instance);
+            var propertyInfo = elementHandle.GetType().GetProperty("Page", BindingFlags.NonPublic | BindingFlags.Instance);
             var methodInfo = propertyInfo.GetGetMethod(nonPublic: true);
 
             return (IPage)methodInfo.Invoke(elementHandle, null);

--- a/src/PuppeteerSharp.Contrib.PageObjects/Extensions/PageExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/Extensions/PageExtensions.cs
@@ -6,7 +6,7 @@ using PuppeteerSharp.Contrib.PageObjects.DynamicProxy;
 namespace PuppeteerSharp.Contrib.PageObjects
 {
     /// <summary>
-    /// <see cref="Page"/> extension methods.
+    /// <see cref="IPage"/> extension methods.
     /// </summary>
     public static class PageExtensions
     {
@@ -16,12 +16,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Navigates to an url and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="url">URL to navigate page to. The url should include scheme, e.g. <c>https://</c>.</param>
         /// <param name="options">Navigation options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.GoToAsync(string, NavigationOptions)"/>
-        public static async Task<T> GoToAsync<T>(this Page page, string url, NavigationOptions options)
+        /// <seealso cref="IPage.GoToAsync(string, NavigationOptions)"/>
+        public static async Task<T> GoToAsync<T>(this IPage page, string url, NavigationOptions options)
             where T : PageObject
         {
             var response = await page.GuardFromNull().GoToAsync(url, options).ConfigureAwait(false);
@@ -33,12 +33,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Navigates to an url and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="url">URL to navigate page to. The url should include scheme, e.g. <c>https://</c>.</param>
         /// <param name="waitUntil">When to consider navigation succeeded.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.GoToAsync(string, WaitUntilNavigation)"/>
-        public static async Task<T> GoToAsync<T>(this Page page, string url, WaitUntilNavigation waitUntil)
+        /// <seealso cref="IPage.GoToAsync(string, WaitUntilNavigation)"/>
+        public static async Task<T> GoToAsync<T>(this IPage page, string url, WaitUntilNavigation waitUntil)
             where T : PageObject
         {
             var response = await page.GuardFromNull().GoToAsync(url, waitUntil).ConfigureAwait(false);
@@ -50,13 +50,13 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Navigates to an url and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="url">URL to navigate page to. The url should include scheme, e.g. <c>https://</c>.</param>
         /// <param name="timeout">Maximum navigation time in milliseconds, defaults to 30 seconds, pass <c>0</c> to disable timeout.</param>
         /// <param name="waitUntil">When to consider navigation succeeded, defaults to <see cref="WaitUntilNavigation.Load"/>. Given an array of <see cref="WaitUntilNavigation"/>, navigation is considered to be successful after all events have been fired.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.GoToAsync(string, int?, WaitUntilNavigation[])"/>
-        public static async Task<T> GoToAsync<T>(this Page page, string url, int? timeout = null, WaitUntilNavigation[]? waitUntil = null)
+        /// <seealso cref="IPage.GoToAsync(string, int?, WaitUntilNavigation[])"/>
+        public static async Task<T> GoToAsync<T>(this IPage page, string url, int? timeout = null, WaitUntilNavigation[]? waitUntil = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().GoToAsync(url, timeout, waitUntil).ConfigureAwait(false);
@@ -68,13 +68,13 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Reloads the page and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="options">Navigation options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.
         /// In case of multiple redirects, the navigation will resolve with the response of the last redirect.
         /// </returns>
-        /// <seealso cref="Page.ReloadAsync(NavigationOptions)"/>
-        public static async Task<T> ReloadAsync<T>(this Page page, NavigationOptions options)
+        /// <seealso cref="IPage.ReloadAsync(NavigationOptions)"/>
+        public static async Task<T> ReloadAsync<T>(this IPage page, NavigationOptions options)
             where T : PageObject
         {
             var response = await page.GuardFromNull().ReloadAsync(options).ConfigureAwait(false);
@@ -86,14 +86,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Reloads the page and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="timeout">Maximum navigation time in milliseconds, defaults to 30 seconds, pass <c>0</c> to disable timeout. </param>
         /// <param name="waitUntil">When to consider navigation succeeded, defaults to <see cref="WaitUntilNavigation.Load"/>. Given an array of <see cref="WaitUntilNavigation"/>, navigation is considered to be successful after all events have been fired.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.
         /// In case of multiple redirects, the navigation will resolve with the response of the last redirect.
         /// </returns>
-        /// <seealso cref="Page.ReloadAsync(int?, WaitUntilNavigation[])"/>
-        public static async Task<T> ReloadAsync<T>(this Page page, int? timeout = null, WaitUntilNavigation[]? waitUntil = null)
+        /// <seealso cref="IPage.ReloadAsync(int?, WaitUntilNavigation[])"/>
+        public static async Task<T> ReloadAsync<T>(this IPage page, int? timeout = null, WaitUntilNavigation[]? waitUntil = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().ReloadAsync(timeout, waitUntil).ConfigureAwait(false);
@@ -107,14 +107,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// It is useful for when you run code which will indirectly cause the page to navigate.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="options">Navigation options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.
         /// In case of multiple redirects, the navigation will resolve with the response of the last redirect.
         /// In case of navigation to a different anchor or navigation due to History API usage, the navigation will resolve with <c>null</c>.
         /// </returns>
-        /// <seealso cref="Page.WaitForNavigationAsync(NavigationOptions)"/>
-        public static async Task<T> WaitForNavigationAsync<T>(this Page page, NavigationOptions? options = null)
+        /// <seealso cref="IPage.WaitForNavigationAsync(NavigationOptions)"/>
+        public static async Task<T> WaitForNavigationAsync<T>(this IPage page, NavigationOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().WaitForNavigationAsync(options).ConfigureAwait(false);
@@ -126,12 +126,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a response and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="url">URL to wait for.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.WaitForResponseAsync(string, WaitForOptions)"/>
-        public static async Task<T> WaitForResponseAsync<T>(this Page page, string url, WaitForOptions? options = null)
+        /// <seealso cref="IPage.WaitForResponseAsync(string, WaitForOptions)"/>
+        public static async Task<T> WaitForResponseAsync<T>(this IPage page, string url, WaitForOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().WaitForResponseAsync(url, options).ConfigureAwait(false);
@@ -143,12 +143,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a response and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="predicate">Function which looks for a matching response.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.WaitForResponseAsync(Func{Response, bool}, WaitForOptions)"/>
-        public static async Task<T> WaitForResponseAsync<T>(this Page page, Func<Response, bool> predicate, WaitForOptions? options = null)
+        /// <seealso cref="IPage.WaitForResponseAsync(Func{IResponse, bool}, WaitForOptions)"/>
+        public static async Task<T> WaitForResponseAsync<T>(this IPage page, Func<IResponse, bool> predicate, WaitForOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().WaitForResponseAsync(predicate, options).ConfigureAwait(false);
@@ -160,12 +160,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a response and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="predicate">Function which looks for a matching response.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.</returns>
-        /// <seealso cref="Page.WaitForResponseAsync(Func{Response, Task{bool}}, WaitForOptions)"/>
-        public static async Task<T> WaitForResponseAsync<T>(this Page page, Func<Response, Task<bool>> predicate, WaitForOptions? options = null)
+        /// <seealso cref="IPage.WaitForResponseAsync(Func{IResponse, Task{bool}}, WaitForOptions)"/>
+        public static async Task<T> WaitForResponseAsync<T>(this IPage page, Func<IResponse, Task<bool>> predicate, WaitForOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().WaitForResponseAsync(predicate, options).ConfigureAwait(false);
@@ -177,14 +177,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Navigate to the previous page in history and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="options">Navigation options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.
         /// In case of multiple redirects, the navigation will resolve with the response of the last redirect.
         /// If can not go back, resolves to <c>null</c>.
         /// </returns>
-        /// <seealso cref="Page.GoBackAsync(NavigationOptions)"/>
-        public static async Task<T?> GoBackAsync<T>(this Page page, NavigationOptions? options = null)
+        /// <seealso cref="IPage.GoBackAsync(NavigationOptions)"/>
+        public static async Task<T?> GoBackAsync<T>(this IPage page, NavigationOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().GoBackAsync(options).ConfigureAwait(false);
@@ -198,14 +198,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Navigate to the next page in history and returns a <see cref="PageObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="PageObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="options">Navigation options.</param>
         /// <returns>Task which resolves to the <see cref="PageObject"/>.
         /// In case of multiple redirects, the navigation will resolve with the response of the last redirect.
         /// If can not go forward, resolves to <c>null</c>.
         /// </returns>
-        /// <seealso cref="Page.GoForwardAsync(NavigationOptions)"/>
-        public static async Task<T?> GoForwardAsync<T>(this Page page, NavigationOptions? options = null)
+        /// <seealso cref="IPage.GoForwardAsync(NavigationOptions)"/>
+        public static async Task<T?> GoForwardAsync<T>(this IPage page, NavigationOptions? options = null)
             where T : PageObject
         {
             var response = await page.GuardFromNull().GoForwardAsync(options).ConfigureAwait(false);
@@ -222,11 +222,11 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the selector, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="selector">A selector to query page for.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/> array.</returns>
-        /// <seealso cref="Page.QuerySelectorAllAsync(string)"/>
-        public static async Task<T[]> QuerySelectorAllAsync<T>(this Page page, string selector)
+        /// <seealso cref="IPage.QuerySelectorAllAsync(string)"/>
+        public static async Task<T[]> QuerySelectorAllAsync<T>(this IPage page, string selector)
             where T : ElementObject
         {
             var results = await page.GuardFromNull().QuerySelectorAllAsync(selector).ConfigureAwait(false);
@@ -239,11 +239,11 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the selector, the return value resolve to <c>null</c>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="selector">A selector to query page for.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/>.</returns>
-        /// <seealso cref="Page.QuerySelectorAsync(string)"/>
-        public static async Task<T?> QuerySelectorAsync<T>(this Page page, string selector)
+        /// <seealso cref="IPage.QuerySelectorAsync(string)"/>
+        public static async Task<T?> QuerySelectorAsync<T>(this IPage page, string selector)
             where T : ElementObject
         {
             var result = await page.GuardFromNull().QuerySelectorAsync(selector).ConfigureAwait(false);
@@ -255,14 +255,14 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a selector to be added to the DOM and returns an <see cref="ElementObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="selector">A selector of an element to wait for.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>A task that resolves to the <see cref="ElementObject"/>, when a element specified by selector string is added to DOM.
         /// Resolves to <c>null</c> if waiting for <c>hidden: true</c> and selector is not found in DOM.
         /// </returns>
-        /// <seealso cref="Page.WaitForSelectorAsync(string, WaitForSelectorOptions)"/>
-        public static async Task<T?> WaitForSelectorAsync<T>(this Page page, string selector, WaitForSelectorOptions? options = null)
+        /// <seealso cref="IPage.WaitForSelectorAsync(string, WaitForSelectorOptions)"/>
+        public static async Task<T?> WaitForSelectorAsync<T>(this IPage page, string selector, WaitForSelectorOptions? options = null)
             where T : ElementObject
         {
             var result = await page.GuardFromNull().WaitForSelectorAsync(selector, options).ConfigureAwait(false);
@@ -274,14 +274,15 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// Waits for a XPath expression to be added to the DOM and returns an <see cref="ElementObject"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="xpath">A XPath expression of an element to wait for.</param>
         /// <param name="options">Waiting options.</param>
         /// <returns>A task that resolves to the <see cref="ElementObject"/>, when a element specified by xpath string is added to DOM.
         /// Resolves to <c>null</c> if waiting for <c>hidden: true</c> and xpath is not found in DOM.
         /// </returns>
-        /// <seealso cref="Page.WaitForXPathAsync(string, WaitForSelectorOptions)"/>
-        public static async Task<T?> WaitForXPathAsync<T>(this Page page, string xpath, WaitForSelectorOptions? options = null)
+        /// <seealso cref="IPage.WaitForXPathAsync(string, WaitForSelectorOptions)"/>
+        [Obsolete("Use " + nameof(WaitForSelectorAsync) + " instead")]
+        public static async Task<T?> WaitForXPathAsync<T>(this IPage page, string xpath, WaitForSelectorOptions? options = null)
             where T : ElementObject
         {
             var result = await page.GuardFromNull().WaitForXPathAsync(xpath, options).ConfigureAwait(false);
@@ -294,11 +295,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// If no elements match the expression, the return value resolve to <see cref="System.Array.Empty{T}"/>.
         /// </summary>
         /// <typeparam name="T">The type of <see cref="ElementObject"/>.</typeparam>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="expression">Expression to evaluate <see href="https://developer.mozilla.org/en-US/docs/Web/API/Document/evaluate"/>.</param>
         /// <returns>Task which resolves to the <see cref="ElementObject"/> array.</returns>
-        /// <seealso cref="Page.XPathAsync(string)"/>
-        public static async Task<T[]> XPathAsync<T>(this Page page, string expression)
+        /// <seealso cref="IPage.XPathAsync(string)"/>
+        [Obsolete("Use " + nameof(QuerySelectorAsync) + " instead")]
+        public static async Task<T[]> XPathAsync<T>(this IPage page, string expression)
             where T : ElementObject
         {
             var results = await page.GuardFromNull().XPathAsync(expression).ConfigureAwait(false);
@@ -306,7 +308,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
             return results.Select(x => ProxyFactory.ElementObject<T>(page, x)).ToArray()!;
         }
 
-        private static Page GuardFromNull(this Page page)
+        private static IPage GuardFromNull(this IPage page)
         {
             if (page == null) throw new ArgumentNullException(nameof(page));
 

--- a/src/PuppeteerSharp.Contrib.PageObjects/PageObject.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/PageObject.cs
@@ -2,7 +2,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
 {
     /// <summary>
     /// <para>Base class for page objects.</para>
-    /// <para>Create page objects by inheriting <see cref="PageObject"/> and declare properties decorated with <see cref="SelectorAttribute"/> or <see cref="XPathAttribute"/>.</para>
+    /// <para>Create page objects by inheriting <see cref="PageObject"/> and declare properties decorated with <see cref="SelectorAttribute"/>.</para>
     /// </summary>
     /// <example>
     /// Usage:
@@ -21,12 +21,6 @@ namespace PuppeteerSharp.Contrib.PageObjects
     ///
     ///     [Selector(".bar")]
     ///     public virtual Task<BarElementObject[]> SelectorForElementObjectArray { get; }
-    ///
-    ///     [XPath("//div")]
-    ///     public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
-    ///
-    ///     [XPath("//div")]
-    ///     public virtual Task<FooElementObject[]> XPathForElementObjectArray { get; }
     /// }
     /// ]]>
     /// </code>
@@ -36,16 +30,12 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// <summary>
         /// The <c>PuppeteerSharp</c> page.
         /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public IPage Page { get; private set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public IPage Page { get; private set; } = null!;
 
         /// <summary>
         /// The response from page navigation.
         /// </summary>
-#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public IResponse Response { get; private set; }
-#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public IResponse Response { get; private set; } = null!;
 
         internal void Initialize(IPage page, IResponse response)
         {

--- a/src/PuppeteerSharp.Contrib.PageObjects/PageObject.cs
+++ b/src/PuppeteerSharp.Contrib.PageObjects/PageObject.cs
@@ -11,10 +11,10 @@ namespace PuppeteerSharp.Contrib.PageObjects
     /// public class FooPageObject : PageObject
     /// {
     ///     [Selector("#foo")]
-    ///     public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+    ///     public virtual Task<IElementHandle> SelectorForElementHandle { get; }
     ///
     ///     [Selector(".bar")]
-    ///     public virtual Task<ElementHandle[]> SelectorForElementHandleArray { get; }
+    ///     public virtual Task<IElementHandle[]> SelectorForElementHandleArray { get; }
     ///
     ///     [Selector("#foo")]
     ///     public virtual Task<FooElementObject> SelectorForElementObject { get; }
@@ -23,7 +23,7 @@ namespace PuppeteerSharp.Contrib.PageObjects
     ///     public virtual Task<BarElementObject[]> SelectorForElementObjectArray { get; }
     ///
     ///     [XPath("//div")]
-    ///     public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+    ///     public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
     ///
     ///     [XPath("//div")]
     ///     public virtual Task<FooElementObject[]> XPathForElementObjectArray { get; }
@@ -37,17 +37,17 @@ namespace PuppeteerSharp.Contrib.PageObjects
         /// The <c>PuppeteerSharp</c> page.
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public Page Page { get; private set; }
+        public IPage Page { get; private set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         /// <summary>
         /// The response from page navigation.
         /// </summary>
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        public Response Response { get; private set; }
+        public IResponse Response { get; private set; }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-        internal void Initialize(Page page, Response response)
+        internal void Initialize(IPage page, IResponse response)
         {
             Page = page;
             Response = response;

--- a/src/PuppeteerSharp.Contrib.PageObjects/PuppeteerSharp.Contrib.PageObjects.csproj
+++ b/src/PuppeteerSharp.Contrib.PageObjects/PuppeteerSharp.Contrib.PageObjects.csproj
@@ -39,7 +39,7 @@ New extensions for ElementHandle:
   <Import Project="../../Analyzers.props" />
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.1.0" />
+    <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
   </ItemGroup>
 

--- a/src/PuppeteerSharp.Contrib.PageObjects/PuppeteerSharp.Contrib.PageObjects.csproj
+++ b/src/PuppeteerSharp.Contrib.PageObjects/PuppeteerSharp.Contrib.PageObjects.csproj
@@ -6,13 +6,13 @@
     <PackageReleaseNotes>
 ⬆️ Bump PuppeteerSharp to 7.1.0
 
-New extensions for Page:
+New extensions for IPage:
 ◼️ GoBackAsync&lt;T&gt;
 ◼️ GoForwardAsync&lt;T&gt;
 ◼️ ReloadAsync&lt;T&gt;
 ◼️ WaitForResponseAsync&lt;T&gt;
 
-New extensions for ElementHandle:
+New extensions for IElementHandle:
 ◼️ WaitForSelectorAsync&lt;T&gt;
     </PackageReleaseNotes>
     <Authors>Henrik Lau Eriksson</Authors>
@@ -40,7 +40,7 @@ New extensions for ElementHandle:
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="5.1.1" />
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
+    <PackageReference Include="PuppeteerSharp" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PuppeteerSharp.Contrib.Should/ElementHandleShouldExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should/ElementHandleShouldExtensions.cs
@@ -4,7 +4,7 @@ using PuppeteerSharp.Contrib.Extensions;
 namespace PuppeteerSharp.Contrib.Should
 {
     /// <summary>
-    /// Should assertions for <see cref="ElementHandle"/>.
+    /// Should assertions for <see cref="IElementHandle"/>.
     /// </summary>
     public static class ElementHandleShouldExtensions
     {
@@ -13,10 +13,10 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element exists.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <returns>The <see cref="ElementHandle"/> for method chaining.</returns>
-        public static ElementHandle ShouldExist(this ElementHandle elementHandle, string? because = null)
+        /// <returns>The <see cref="IElementHandle"/> for method chaining.</returns>
+        public static IElementHandle ShouldExist(this IElementHandle elementHandle, string? because = null)
         {
             if (!elementHandle.Exists()) Throw.ElementShouldExist(because);
 
@@ -26,10 +26,10 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not exist.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
-        /// <returns>The <see cref="ElementHandle"/> for method chaining.</returns>
-        public static ElementHandle ShouldNotExist(this ElementHandle elementHandle, string? because = null)
+        /// <returns>The <see cref="IElementHandle"/> for method chaining.</returns>
+        public static IElementHandle ShouldNotExist(this IElementHandle elementHandle, string? because = null)
         {
             if (elementHandle.Exists()) Throw.ElementShouldNotExist(because);
 
@@ -41,12 +41,12 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element has the specified value.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="value">The value.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <option>, <input>, <li>, <meter>, <progress>, <param>]]></remarks>
-        public static async Task ShouldHaveValueAsync(this ElementHandle elementHandle, string value, string? because = null)
+        public static async Task ShouldHaveValueAsync(this IElementHandle elementHandle, string value, string? because = null)
         {
             var actual = await elementHandle.ValueAsync().ConfigureAwait(false);
 
@@ -56,12 +56,12 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not have the specified value.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="value">The value.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <option>, <input>, <li>, <meter>, <progress>, <param>]]></remarks>
-        public static async Task ShouldNotHaveValueAsync(this ElementHandle elementHandle, string value, string? because = null)
+        public static async Task ShouldNotHaveValueAsync(this IElementHandle elementHandle, string value, string? because = null)
         {
             if (await elementHandle.ValueAsync().ConfigureAwait(false) == value) Throw.ElementShouldNotHaveValue(value, because);
         }
@@ -71,11 +71,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element has the specified attribute.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="name">The attribute name.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldHaveAttributeAsync(this ElementHandle elementHandle, string name, string? because = null)
+        public static async Task ShouldHaveAttributeAsync(this IElementHandle elementHandle, string name, string? because = null)
         {
             if (!await elementHandle.HasAttributeAsync(name).ConfigureAwait(false)) Throw.ElementShouldHaveAttribute(name, because);
         }
@@ -83,11 +83,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not have the specified attribute.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="name">The attribute name.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldNotHaveAttributeAsync(this ElementHandle elementHandle, string name, string? because = null)
+        public static async Task ShouldNotHaveAttributeAsync(this IElementHandle elementHandle, string name, string? because = null)
         {
             if (await elementHandle.HasAttributeAsync(name).ConfigureAwait(false)) Throw.ElementShouldNotHaveAttribute(name, because);
         }
@@ -97,13 +97,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element has the specified content.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldHaveContentAsync(this ElementHandle elementHandle, string regex, string flags = "", string? because = null)
+        public static async Task ShouldHaveContentAsync(this IElementHandle elementHandle, string regex, string flags = "", string? because = null)
         {
             if (!await elementHandle.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ElementShouldHaveContent(regex, flags, because);
         }
@@ -111,13 +111,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not have the specified content.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="regex">A regular expression to test against <c>element.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldNotHaveContentAsync(this ElementHandle elementHandle, string regex, string flags = "", string? because = null)
+        public static async Task ShouldNotHaveContentAsync(this IElementHandle elementHandle, string regex, string flags = "", string? because = null)
         {
             if (await elementHandle.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.ElementShouldNotHaveContent(regex, flags, because);
         }
@@ -127,11 +127,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element has the specified class.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="className">The class name.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldHaveClassAsync(this ElementHandle elementHandle, string className, string? because = null)
+        public static async Task ShouldHaveClassAsync(this IElementHandle elementHandle, string className, string? because = null)
         {
             if (!await elementHandle.HasClassAsync(className).ConfigureAwait(false)) Throw.ElementShouldHaveClass(className, because);
         }
@@ -139,11 +139,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not have the specified class.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="className">The class name.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldNotHaveClassAsync(this ElementHandle elementHandle, string className, string? because = null)
+        public static async Task ShouldNotHaveClassAsync(this IElementHandle elementHandle, string className, string? because = null)
         {
             if (await elementHandle.HasClassAsync(className).ConfigureAwait(false)) Throw.ElementShouldNotHaveClass(className, because);
         }
@@ -153,10 +153,10 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is visible.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldBeVisibleAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeVisibleAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsHiddenAsync().ConfigureAwait(false)) Throw.ElementShouldBeVisible(because);
         }
@@ -164,10 +164,10 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is hidden.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task ShouldBeHiddenAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeHiddenAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsVisibleAsync().ConfigureAwait(false)) Throw.ElementShouldBeHidden(because);
         }
@@ -177,11 +177,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is selected.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <option>]]></remarks>
-        public static async Task ShouldBeSelectedAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeSelectedAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (!await elementHandle.IsSelectedAsync().ConfigureAwait(false)) Throw.ElementShouldBeSelected(because);
         }
@@ -189,11 +189,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is not selected.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <option>]]></remarks>
-        public static async Task ShouldNotBeSelectedAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldNotBeSelectedAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsSelectedAsync().ConfigureAwait(false)) Throw.ElementShouldNotBeSelected(because);
         }
@@ -203,11 +203,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is checked.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <command>, <input>]]></remarks>
-        public static async Task ShouldBeCheckedAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeCheckedAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (!await elementHandle.IsCheckedAsync().ConfigureAwait(false)) Throw.ElementShouldBeChecked(because);
         }
@@ -215,11 +215,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is not checked.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <command>, <input>]]></remarks>
-        public static async Task ShouldNotBeCheckedAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldNotBeCheckedAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsCheckedAsync().ConfigureAwait(false)) Throw.ElementShouldNotBeChecked(because);
         }
@@ -229,11 +229,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is disabled.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <command>, <fieldset>, <input>, <keygen>, <optgroup>, <option>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldBeDisabledAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeDisabledAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsEnabledAsync().ConfigureAwait(false)) Throw.ElementShouldBeDisabled(because);
         }
@@ -241,11 +241,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is enabled.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <command>, <fieldset>, <input>, <keygen>, <optgroup>, <option>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldBeEnabledAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeEnabledAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsDisabledAsync().ConfigureAwait(false)) Throw.ElementShouldBeEnabled(because);
         }
@@ -255,11 +255,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is read-only.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <input>, <textarea>]]></remarks>
-        public static async Task ShouldBeReadOnlyAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeReadOnlyAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (!await elementHandle.IsReadOnlyAsync().ConfigureAwait(false)) Throw.ElementShouldBeReadOnly(because);
         }
@@ -267,11 +267,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is not read-only.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <input>, <textarea>]]></remarks>
-        public static async Task ShouldNotBeReadOnlyAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldNotBeReadOnlyAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsReadOnlyAsync().ConfigureAwait(false)) Throw.ElementShouldNotBeReadOnly(because);
         }
@@ -281,11 +281,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is required.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <input>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldBeRequiredAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldBeRequiredAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (!await elementHandle.IsRequiredAsync().ConfigureAwait(false)) Throw.ElementShouldBeRequired(because);
         }
@@ -293,11 +293,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element is not required.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <input>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldNotBeRequiredAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldNotBeRequiredAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.IsRequiredAsync().ConfigureAwait(false)) Throw.ElementShouldNotBeRequired(because);
         }
@@ -307,11 +307,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element has focus.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <input>, <keygen>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldHaveFocusAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldHaveFocusAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (!await elementHandle.HasFocusAsync().ConfigureAwait(false)) Throw.ElementShouldHaveFocus(because);
         }
@@ -319,11 +319,11 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the element does not have focus.
         /// </summary>
-        /// <param name="elementHandle">An <see cref="ElementHandle"/>.</param>
+        /// <param name="elementHandle">An <see cref="IElementHandle"/>.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <remarks><![CDATA[Elements: <button>, <input>, <keygen>, <select>, <textarea>]]></remarks>
-        public static async Task ShouldNotHaveFocusAsync(this ElementHandle elementHandle, string? because = null)
+        public static async Task ShouldNotHaveFocusAsync(this IElementHandle elementHandle, string? because = null)
         {
             if (await elementHandle.HasFocusAsync().ConfigureAwait(false)) Throw.ElementShouldNotHaveFocus(because);
         }

--- a/src/PuppeteerSharp.Contrib.Should/InternalExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should/InternalExtensions.cs
@@ -4,7 +4,7 @@ namespace PuppeteerSharp.Contrib.Should
 {
     internal static class InternalExtensions
     {
-        internal static Page GuardFromNull(this Page page)
+        internal static IPage GuardFromNull(this IPage page)
         {
             if (page == null) throw new ArgumentNullException(nameof(page));
 

--- a/src/PuppeteerSharp.Contrib.Should/PageShouldExtensions.cs
+++ b/src/PuppeteerSharp.Contrib.Should/PageShouldExtensions.cs
@@ -4,20 +4,20 @@ using PuppeteerSharp.Contrib.Extensions;
 namespace PuppeteerSharp.Contrib.Should
 {
     /// <summary>
-    /// Should assertions for <see cref="Page"/>.
+    /// Should assertions for <see cref="IPage"/>.
     /// </summary>
     public static class PageShouldExtensions
     {
         /// <summary>
         /// Asserts that the page has the specified content.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldHaveContentAsync(this Page page, string regex, string flags = "", string? because = null)
+        public static async Task ShouldHaveContentAsync(this IPage page, string regex, string flags = "", string? because = null)
         {
             if (!await page.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.PageShouldHaveContent(regex, flags, because);
         }
@@ -25,13 +25,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the page does not have the specified content.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.documentElement.textContent</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldNotHaveContentAsync(this Page page, string regex, string flags = "", string? because = null)
+        public static async Task ShouldNotHaveContentAsync(this IPage page, string regex, string flags = "", string? because = null)
         {
             if (await page.HasContentAsync(regex, flags).ConfigureAwait(false)) Throw.PageShouldNotHaveContent(regex, flags, because);
         }
@@ -39,13 +39,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the page has the specified title.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.title</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldHaveTitleAsync(this Page page, string regex, string flags = "", string? because = null)
+        public static async Task ShouldHaveTitleAsync(this IPage page, string regex, string flags = "", string? because = null)
         {
             if (!await page.HasTitleAsync(regex, flags).ConfigureAwait(false)) Throw.PageShouldHaveTitle(regex, flags, await page.GuardFromNull().GetTitleAsync().ConfigureAwait(false), because);
         }
@@ -53,13 +53,13 @@ namespace PuppeteerSharp.Contrib.Should
         /// <summary>
         /// Asserts that the page does not have the specified title.
         /// </summary>
-        /// <param name="page">A <see cref="Page"/>.</param>
+        /// <param name="page">A <see cref="IPage"/>.</param>
         /// <param name="regex">A regular expression to test against <c>document.title</c>.</param>
         /// <param name="flags">A set of flags for the regular expression.</param>
         /// <param name="because">A phrase explaining why the assertion is needed. If the phrase does not start with the word <i>because</i>, it is prepended automatically.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp"/>
-        public static async Task ShouldNotHaveTitleAsync(this Page page, string regex, string flags = "", string? because = null)
+        public static async Task ShouldNotHaveTitleAsync(this IPage page, string regex, string flags = "", string? because = null)
         {
             if (await page.HasTitleAsync(regex, flags).ConfigureAwait(false)) Throw.PageShouldNotHaveTitle(regex, flags, because);
         }

--- a/src/PuppeteerSharp.Contrib.Should/PuppeteerSharp.Contrib.Should.csproj
+++ b/src/PuppeteerSharp.Contrib.Should/PuppeteerSharp.Contrib.Should.csproj
@@ -30,7 +30,7 @@
   <Import Project="../../Analyzers.props" />
 
   <ItemGroup>
-    <PackageReference Include="PuppeteerSharp" Version="7.1.0" />
+    <PackageReference Include="PuppeteerSharp" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PuppeteerSharp.Contrib.Should/Throw.cs
+++ b/src/PuppeteerSharp.Contrib.Should/Throw.cs
@@ -2,7 +2,7 @@ namespace PuppeteerSharp.Contrib.Should
 {
     internal static class Throw
     {
-        /* Page */
+        /* IPage */
 
         public static void PageShouldHaveContent(string regex, string flags, string? because)
         {
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Contrib.Should
             throw Exception($"Expected page not to have title \"/{regex}/{flags}\"", null, because);
         }
 
-        /* ElementHandle */
+        /* IElementHandle */
 
         public static void ElementShouldExist(string? because)
         {

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/ElementHandleExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/ElementHandleExtensionsTests.cs
@@ -7,7 +7,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
 {
     public class ElementHandleExtensionsTests : PuppeteerPageBaseTest
     {
-        private ElementHandle _elementHandle;
+        private IElementHandle _elementHandle;
 
         protected override async Task SetUp()
         {

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/Fake.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/Fake.cs
@@ -14,10 +14,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
     public class FakePageObject : PageObject
     {
         [Selector(".tweet")]
-        public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+        public virtual Task<IElementHandle> SelectorForElementHandle { get; }
 
         [Selector("div")]
-        public virtual Task<ElementHandle[]> SelectorForElementHandleArray { get; }
+        public virtual Task<IElementHandle[]> SelectorForElementHandleArray { get; }
 
         [Selector(".retweets")]
         public virtual Task<FakeElementObject> SelectorForElementObject { get; }
@@ -26,7 +26,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         public virtual Task<FakeElementObject[]> SelectorForElementObjectArray { get; }
 
         [XPath("//div")]
-        public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+        public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
 
         [XPath("//div")]
         public virtual Task<FakeElementObject[]> XPathForElementObjectArray { get; }
@@ -37,7 +37,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         public virtual Task<object> SelectorForWrongReturnType { get; }
 
         [Selector(".tweet")]
-        public virtual ElementHandle SelectorForNonTaskReturnType { get; }
+        public virtual IElementHandle SelectorForNonTaskReturnType { get; }
 
         [Selector(".retweets")]
         public virtual FakeElementObject SelectorForElementObjectWithNonTaskReturnType { get; }
@@ -49,16 +49,16 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         public virtual Task<object[]> XPathForWrongReturnType { get; }
 
         [XPath("//div")]
-        public virtual ElementHandle[] XPathForNonTaskReturnType { get; }
+        public virtual IElementHandle[] XPathForNonTaskReturnType { get; }
     }
 
     public class FakeElementObject : ElementObject
     {
         [Selector(".tweet")]
-        public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+        public virtual Task<IElementHandle> SelectorForElementHandle { get; }
 
         [Selector("div")]
-        public virtual Task<ElementHandle[]> SelectorForElementHandleArray { get; }
+        public virtual Task<IElementHandle[]> SelectorForElementHandleArray { get; }
 
         [Selector(".retweets")]
         public virtual Task<FakeElementObject> SelectorForElementObject { get; }
@@ -67,7 +67,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         public virtual Task<FakeElementObject[]> SelectorForElementObjectArray { get; }
 
         [XPath("//div")]
-        public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+        public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
 
         [XPath("//div")]
         public virtual Task<FakeElementObject[]> XPathForElementObjectArray { get; }
@@ -78,22 +78,22 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         public virtual Task<object> SelectorForWrongReturnType { get; }
 
         [Selector(".tweet")]
-        public virtual ElementHandle SelectorForNonTaskReturnType { get; }
+        public virtual IElementHandle SelectorForNonTaskReturnType { get; }
 
         [XPath("//div")]
         public virtual Task<object[]> XPathForWrongReturnType { get; }
 
         [XPath("//div")]
-        public virtual ElementHandle[] XPathForNonTaskReturnType { get; }
+        public virtual IElementHandle[] XPathForNonTaskReturnType { get; }
     }
 
     public class FakeObjectWithNoBaseClass
     {
         [Selector(".tweet")]
-        public virtual Task<ElementHandle> SelectorForElementHandle { get; }
+        public virtual Task<IElementHandle> SelectorForElementHandle { get; }
 
         [XPath("//div")]
-        public virtual Task<ElementHandle[]> XPathForElementHandleArray { get; }
+        public virtual Task<IElementHandle[]> XPathForElementHandleArray { get; }
     }
 
     public class FakeInvocation(MethodInfo proxiedMethod, object proxy = null) : AbstractInvocation(proxy, null, proxiedMethod, null)

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/InvocationExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/InvocationExtensionsTests.cs
@@ -54,7 +54,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         {
             var methodInfo = typeof(FakePageObject).GetProperty(nameof(FakePageObject.SelectorForElementHandle)).GetMethod;
             var invocation = new FakeInvocation(methodInfo);
-            Assert.True(invocation.IsReturning<ElementHandle>());
+            Assert.True(invocation.IsReturning<IElementHandle>());
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         {
             var methodInfo = typeof(FakePageObject).GetProperty(nameof(FakePageObject.SelectorForNonTaskReturnType)).GetMethod;
             var invocation = new FakeInvocation(methodInfo);
-            Assert.False(invocation.IsReturning<ElementHandle>());
+            Assert.False(invocation.IsReturning<IElementHandle>());
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(pageObject, new SelectorAttribute(".tweet"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle>(result);
+            Assert.IsInstanceOf<IElementHandle>(result);
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(pageObject, new SelectorAttribute("div"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]
@@ -194,7 +194,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(elementObject, new SelectorAttribute(".tweet"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle>(result);
+            Assert.IsInstanceOf<IElementHandle>(result);
         }
 
         [Test]
@@ -209,7 +209,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(elementObject, new SelectorAttribute("div"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]
@@ -281,7 +281,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(pageObject, new XPathAttribute("//div"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]
@@ -337,7 +337,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var result = await invocation.GetReturnValueAsync(elementObject, new XPathAttribute("//div"));
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/InvocationExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/InvocationExtensionsTests.cs
@@ -100,7 +100,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // PageObject
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_for_property_on_PageObject_marked_with_SelectorAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_for_property_on_PageObject_marked_with_SelectorAttribute()
         {
             var pageObject = new FakePageObject();
             pageObject.Initialize(Page, null);
@@ -114,7 +114,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         }
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_array_for_property_on_PageObject_marked_with_SelectorAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_array_for_property_on_PageObject_marked_with_SelectorAttribute()
         {
             var pageObject = new FakePageObject();
             pageObject.Initialize(Page, null);
@@ -183,7 +183,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // ElementObject
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_for_property_on_ElementObject_marked_with_SelectorAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_for_property_on_ElementObject_marked_with_SelectorAttribute()
         {
             var elementHandle = await Page.QuerySelectorAsync("html");
             var elementObject = new FakeElementObject();
@@ -198,7 +198,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         }
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_array_for_property_on_ElementObject_marked_with_SelectorAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_array_for_property_on_ElementObject_marked_with_SelectorAttribute()
         {
             var elementHandle = await Page.QuerySelectorAsync("html");
             var elementObject = new FakeElementObject();
@@ -271,7 +271,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // PageObject
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_array_for_property_on_PageObject_marked_with_XPathAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_array_for_property_on_PageObject_marked_with_XPathAttribute()
         {
             var pageObject = new FakePageObject();
             pageObject.Initialize(Page, null);
@@ -326,7 +326,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // ElementObject
 
         [Test]
-        public async Task GetReturnValueAsync_returns_ElementHandle_array_for_property_on_ElementObject_marked_with_XPathAttribute()
+        public async Task GetReturnValueAsync_returns_IElementHandle_array_for_property_on_ElementObject_marked_with_XPathAttribute()
         {
             var elementHandle = await Page.QuerySelectorAsync("html");
             var elementObject = new FakeElementObject();

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/PageExtensionsTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/PageExtensionsTests.cs
@@ -74,7 +74,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             Assert.NotNull(result);
             Assert.IsInstanceOf<FakePageObject>(result);
 
-            task = Page.WaitForResponseAsync<FakePageObject>(async (Response response) =>
+            task = Page.WaitForResponseAsync<FakePageObject>(async (IResponse response) =>
             {
                 await Task.Delay(1);
                 return response.Url == "https://github.com/hardkoded/puppeteer-sharp";

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/ProxyFactoryTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/ProxyFactoryTests.cs
@@ -56,7 +56,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             Assert.IsNotEmpty(result);
             CollectionAssert.AllItemsAreInstancesOfType(result, typeof(FakeElementObject));
 
-            result = ProxyFactory.ElementObjectArray(typeof(FakeElementObject), Page, Array.Empty<ElementHandle>());
+            result = ProxyFactory.ElementObjectArray(typeof(FakeElementObject), Page, Array.Empty<IElementHandle>());
             Assert.IsEmpty(result);
         }
     }

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/SelectorInterceptorTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/SelectorInterceptorTests.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // PageObject
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_for_property_on_PageObject_marked_with_SelectorAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_for_property_on_PageObject_marked_with_SelectorAttribute()
         {
             var methodInfo = _pageObject.GetType().GetProperty(nameof(FakePageObject.SelectorForElementHandle)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _pageObject);
@@ -37,7 +37,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         }
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_array_for_property_on_PageObject_marked_with_SelectorAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_array_for_property_on_PageObject_marked_with_SelectorAttribute()
         {
             var methodInfo = _pageObject.GetType().GetProperty(nameof(FakePageObject.SelectorForElementHandleArray)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _pageObject);
@@ -87,7 +87,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // ElementObject
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_for_property_on_ElementObject_marked_with_SelectorAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_for_property_on_ElementObject_marked_with_SelectorAttribute()
         {
             var methodInfo = _elementObject.GetType().GetProperty(nameof(FakeElementObject.SelectorForElementHandle)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _elementObject);
@@ -100,7 +100,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         }
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_array_for_property_on_ElementObject_marked_with_SelectorAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_array_for_property_on_ElementObject_marked_with_SelectorAttribute()
         {
             var methodInfo = _elementObject.GetType().GetProperty(nameof(FakeElementObject.SelectorForElementHandleArray)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _elementObject);

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/SelectorInterceptorTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/SelectorInterceptorTests.cs
@@ -30,10 +30,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _pageObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle>(result);
+            Assert.IsInstanceOf<IElementHandle>(result);
         }
 
         [Test]
@@ -43,10 +43,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _pageObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle[]>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle[]>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]
@@ -93,10 +93,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _elementObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle>(result);
+            Assert.IsInstanceOf<IElementHandle>(result);
         }
 
         [Test]
@@ -106,10 +106,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _elementObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle[]>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle[]>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/XPathInterceptorTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/XPathInterceptorTests.cs
@@ -24,7 +24,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // PageObject
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_array_for_property_on_PageObject_marked_with_XPathAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_array_for_property_on_PageObject_marked_with_XPathAttribute()
         {
             var methodInfo = _pageObject.GetType().GetProperty(nameof(FakePageObject.XPathForElementHandleArray)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _pageObject);
@@ -61,7 +61,7 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
         // ElementObject
 
         [Test]
-        public async Task Intercept_sets_the_ReturnValue_to_Task_of_ElementHandle_array_for_property_on_ElementObject_marked_with_XPathAttribute()
+        public async Task Intercept_sets_the_ReturnValue_to_Task_of_IElementHandle_array_for_property_on_ElementObject_marked_with_XPathAttribute()
         {
             var methodInfo = _elementObject.GetType().GetProperty(nameof(FakeElementObject.XPathForElementHandleArray)).GetMethod;
             var invocation = new FakeInvocation(methodInfo, _elementObject);

--- a/tests/PuppeteerSharp.Contrib.Tests/PageObjects/XPathInterceptorTests.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PageObjects/XPathInterceptorTests.cs
@@ -30,10 +30,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _pageObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle[]>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle[]>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]
@@ -67,10 +67,10 @@ namespace PuppeteerSharp.Contrib.Tests.PageObjects
             var invocation = new FakeInvocation(methodInfo, _elementObject);
 
             _subject.Intercept(invocation);
-            var result = await (Task<ElementHandle[]>)invocation.ReturnValue;
+            var result = await (Task<IElementHandle[]>)invocation.ReturnValue;
 
             Assert.NotNull(result);
-            Assert.IsInstanceOf<ElementHandle[]>(result);
+            Assert.IsInstanceOf<IElementHandle[]>(result);
         }
 
         [Test]

--- a/tests/PuppeteerSharp.Contrib.Tests/PuppeteerPageBaseTest.cs
+++ b/tests/PuppeteerSharp.Contrib.Tests/PuppeteerPageBaseTest.cs
@@ -5,9 +5,9 @@ namespace PuppeteerSharp.Contrib.Tests
 {
     public abstract class PuppeteerPageBaseTest
     {
-        private Browser Browser { get; set; }
-        private BrowserContext Context { get; set; }
-        protected Page Page { get; private set; }
+        private IBrowser Browser { get; set; }
+        private IBrowserContext Context { get; set; }
+        protected IPage Page { get; private set; }
 
         [SetUp]
         public async Task CreatePageAsync()


### PR DESCRIPTION
When `PuppeteerSharp` [v8.0.0](https://github.com/hardkoded/puppeteer-sharp/releases/tag/v8.0.0) was released (Oct 6, 2022), `PuppeteerSharp.Contrib` broke:

- https://github.com/hardkoded/puppeteer-sharp/pull/1965